### PR TITLE
Skip node refactoring

### DIFF
--- a/src/rrd/Makefile
+++ b/src/rrd/Makefile
@@ -9,6 +9,7 @@ SRC += src/rrd/pretty_collapse.c
 SRC += src/rrd/pretty_affix.c
 SRC += src/rrd/pretty_bottom.c
 SRC += src/rrd/pretty_redundant.c
+SRC += src/rrd/pretty_skippable.c
 SRC += src/rrd/pretty_roll.c
 SRC += src/rrd/pretty.c
 

--- a/src/rrd/Makefile
+++ b/src/rrd/Makefile
@@ -8,6 +8,7 @@ SRC += src/rrd/stack.c
 SRC += src/rrd/pretty_collapse.c
 SRC += src/rrd/pretty_affix.c
 SRC += src/rrd/pretty_bottom.c
+SRC += src/rrd/pretty_nested.c
 SRC += src/rrd/pretty_redundant.c
 SRC += src/rrd/pretty_skippable.c
 SRC += src/rrd/pretty_roll.c

--- a/src/rrd/list.c
+++ b/src/rrd/list.c
@@ -10,6 +10,7 @@
 #include "../xalloc.h"
 
 #include "list.h"
+#include "node.h"
 
 void
 list_push(struct list **list, struct node *node)
@@ -17,7 +18,6 @@ list_push(struct list **list, struct node *node)
 	struct list *new;
 
 	assert(list != NULL);
-	assert(node != NULL);
 
 	new = xmalloc(sizeof *new);
 	new->node = node;

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -28,6 +28,7 @@ node_free(struct node *n)
 		break;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			node_free(p->node);
 		}
@@ -90,6 +91,20 @@ node_create_alt(struct list *alt)
 	new = xmalloc(sizeof *new);
 
 	new->type = NODE_ALT;
+
+	new->u.alt = alt;
+
+	return new;
+}
+
+struct node *
+node_create_alt_skippable(struct list *alt)
+{
+	struct node *new;
+
+	new = xmalloc(sizeof *new);
+
+	new->type = NODE_ALT_SKIPPABLE;
 
 	new->u.alt = alt;
 
@@ -169,6 +184,7 @@ node_compare(const struct node *a, const struct node *b)
 		return 0 == strcmp(a->u.name, b->u.name);
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		return list_compare(a->u.alt, b->u.alt);
 
 	case NODE_SEQ:

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -18,8 +18,11 @@ node_free(struct node *n)
 {
 	struct list *p;
 
+	if (n == NULL) {
+		return;
+	}
+
 	switch (n->type) {
-	case NODE_SKIP:
 	case NODE_LITERAL:
 	case NODE_RULE:
 		break;
@@ -45,18 +48,6 @@ node_free(struct node *n)
 	}
 
 	free(n);
-}
-
-struct node *
-node_create_skip(void)
-{
-	struct node *new;
-
-	new = xmalloc(sizeof *new);
-
-	new->type = NODE_SKIP;
-
-	return new;
 }
 
 struct node *
@@ -142,10 +133,9 @@ node_make_seq(struct node **n)
 {
 	struct list *new;
 
-	assert(*n != NULL);
 	assert(n != NULL);
 
-	if ((*n)->type == NODE_SEQ) {
+	if (*n != NULL && (*n)->type == NODE_SEQ) {
 		return;
 	}
 
@@ -159,17 +149,19 @@ node_make_seq(struct node **n)
 int
 node_compare(const struct node *a, const struct node *b)
 {
-	assert(a != NULL);
-	assert(b != NULL);
+	if (a == NULL && b == NULL) {
+		return 1;
+	}
+
+	if (a == NULL || b == NULL) {
+		return 0;
+	}
 
 	if (a->type != b->type) {
 		return 0;
 	}
 
 	switch (a->type) {
-	case NODE_SKIP:
-		return 1;
-
 	case NODE_LITERAL:
 		return 0 == strcmp(a->u.literal, b->u.literal);
 

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -12,6 +12,7 @@ struct node {
 		NODE_LITERAL,
 		NODE_RULE,
 		NODE_ALT,
+		NODE_ALT_SKIPPABLE,
 		NODE_SEQ,
 		NODE_LOOP
 	} type;
@@ -43,6 +44,9 @@ node_create_name(const char *name);
 
 struct node *
 node_create_alt(struct list *alt);
+
+struct node *
+node_create_alt_skippable(struct list *alt);
 
 struct node *
 node_create_seq(struct list *seq);

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -9,7 +9,6 @@
 
 struct node {
 	enum {
-		NODE_SKIP,
 		NODE_LITERAL,
 		NODE_RULE,
 		NODE_ALT,
@@ -35,9 +34,6 @@ struct node {
 
 void
 node_free(struct node *);
-
-struct node *
-node_create_skip(void);
 
 struct node *
 node_create_literal(const char *literal);

--- a/src/rrd/pretty.c
+++ b/src/rrd/pretty.c
@@ -21,10 +21,13 @@ static void
 node_walk(void (*f)(int *, struct node **),
 	int *changed, struct node **n)
 {
-	assert(n != NULL);
 	assert(f != NULL);
 
 	f(changed, n);
+
+	if (*n == NULL) {
+		return;
+	}
 
 	switch ((*n)->type) {
 		struct list **p;
@@ -46,7 +49,6 @@ node_walk(void (*f)(int *, struct node **),
 		node_walk(f, changed, &(*n)->u.loop.backward);
 		break;
 
-	case NODE_SKIP:
 	case NODE_RULE:
 	case NODE_LITERAL:
 		break;

--- a/src/rrd/pretty.c
+++ b/src/rrd/pretty.c
@@ -33,6 +33,7 @@ node_walk(void (*f)(int *, struct node **),
 		struct list **p;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		for (p = &(*n)->u.alt; *p != NULL; p = &(**p).next) {
 			node_walk(f, changed, &(*p)->node);
 		}
@@ -63,7 +64,7 @@ rrd_pretty(struct node **rrd)
 	size_t i;
 
 	void (*f[])(int *, struct node **) = {
-		rrd_pretty_collapse, rrd_pretty_redundant,
+		rrd_pretty_collapse, rrd_pretty_skippable, rrd_pretty_redundant,
 		rrd_pretty_collapse, rrd_pretty_roll,
 		rrd_pretty_collapse, rrd_pretty_affixes,
 		rrd_pretty_collapse, rrd_pretty_bottom,

--- a/src/rrd/pretty.c
+++ b/src/rrd/pretty.c
@@ -66,6 +66,7 @@ rrd_pretty(struct node **rrd)
 	void (*f[])(int *, struct node **) = {
 		rrd_pretty_collapse, rrd_pretty_skippable, rrd_pretty_redundant,
 		rrd_pretty_collapse, rrd_pretty_roll,
+		rrd_pretty_collapse, rrd_pretty_nested,
 		rrd_pretty_collapse, rrd_pretty_affixes,
 		rrd_pretty_collapse, rrd_pretty_bottom,
 		rrd_pretty_collapse

--- a/src/rrd/pretty.h
+++ b/src/rrd/pretty.h
@@ -12,6 +12,7 @@ struct node;
 void rrd_pretty_affixes(int *changed, struct node **);
 void rrd_pretty_bottom(int *changed, struct node **);
 void rrd_pretty_redundant(int *changed, struct node **);
+void rrd_pretty_skippable(int *changed, struct node **);
 void rrd_pretty_collapse(int *changed, struct node **);
 void rrd_pretty_roll(int *changed, struct node **);
 

--- a/src/rrd/pretty.h
+++ b/src/rrd/pretty.h
@@ -14,6 +14,7 @@ void rrd_pretty_bottom(int *changed, struct node **);
 void rrd_pretty_redundant(int *changed, struct node **);
 void rrd_pretty_skippable(int *changed, struct node **);
 void rrd_pretty_collapse(int *changed, struct node **);
+void rrd_pretty_nested(int *changed, struct node **);
 void rrd_pretty_roll(int *changed, struct node **);
 
 void rrd_pretty(struct node **rrd);

--- a/src/rrd/pretty_affix.c
+++ b/src/rrd/pretty_affix.c
@@ -164,7 +164,10 @@ void
 rrd_pretty_affixes(int *changed, struct node **n)
 {
 	assert(n != NULL);
-	assert(*n != NULL);
+
+	if (*n == NULL) {
+		return;
+	}
 
 	switch ((*n)->type) {
 		struct list **p;
@@ -184,8 +187,8 @@ rrd_pretty_affixes(int *changed, struct node **n)
 		 */
 
 		for (p = &(*n)->u.seq; *p != NULL; p = &(*p)->next) {
-			if ((*p)->node->type == NODE_LOOP) {
-				if ((*p)->node->u.loop.backward->type == NODE_SKIP) {
+			if ((*p)->node != NULL && (*p)->node->type == NODE_LOOP) {
+				if ((*p)->node->u.loop.backward == NULL) {
 					/* TODO: collapse_suffix() for forward only */
 				} else {
 					collapse_suffix(changed, &(*p)->next, (*p)->node);
@@ -197,8 +200,8 @@ rrd_pretty_affixes(int *changed, struct node **n)
 		}
 
 		for (p = &(*n)->u.seq; *p != NULL; p = &(*p)->next) {
-			if ((*p)->node->type == NODE_LOOP) {
-				if ((*p)->node->u.loop.backward->type == NODE_SKIP) {
+			if ((*p)->node != NULL && (*p)->node->type == NODE_LOOP) {
+				if ((*p)->node->u.loop.backward == NULL) {
 					/* TODO: collapse_prefix() for forward only */
 				} else {
 					collapse_prefix(changed, &(*n)->u.seq, (*p)->node);

--- a/src/rrd/pretty_bottom.c
+++ b/src/rrd/pretty_bottom.c
@@ -22,12 +22,11 @@ bottom_loop(struct node **np)
 
 	n = *np;
 
-	if (n->u.loop.forward->type != NODE_SKIP) {
+	if (n->u.loop.forward != NULL) {
 		return 0;
 	}
 
-	if (n->u.loop.backward->type == NODE_SKIP
-	 || n->u.loop.backward->type == NODE_LOOP) {
+	if (n->u.loop.backward == NULL || n->u.loop.backward->type == NODE_LOOP) {
 		return 0;
 	}
 
@@ -61,7 +60,7 @@ bottom_loop(struct node **np)
 		new  = NULL;
 
 		list_push(&new, n);
-		list_push(&new, node_create_skip());
+		list_push(&new, NULL);
 
 		*np = node_create_alt(new);
 	}
@@ -79,7 +78,10 @@ void
 rrd_pretty_bottom(int *changed, struct node **n)
 {
 	assert(n != NULL);
-	assert(*n != NULL);
+
+	if (*n == NULL) {
+		return;
+	}
 
 	switch ((*n)->type) {
 	case NODE_LOOP:

--- a/src/rrd/pretty_bottom.c
+++ b/src/rrd/pretty_bottom.c
@@ -34,14 +34,14 @@ bottom_loop(struct node **np)
 		return 0;
 	}
 
-	if (n->u.loop.backward->type == NODE_ALT) {
+	if (n->u.loop.backward->type == NODE_ALT || n->u.loop.backward->type == NODE_ALT_SKIPPABLE) {
 		struct list *p;
 		int c;
 
 		c = 0;
 
 		for (p = n->u.loop.backward->u.alt; p != NULL; p = p->next) {
-			if (p->node->type == NODE_ALT || p->node->type == NODE_SEQ || p->node->type == NODE_LOOP) {
+			if (p->node->type == NODE_ALT || p->node->type == NODE_ALT_SKIPPABLE || p->node->type == NODE_SEQ || p->node->type == NODE_LOOP) {
 				c = 1;
 			}
 		}

--- a/src/rrd/pretty_collapse.c
+++ b/src/rrd/pretty_collapse.c
@@ -15,7 +15,10 @@ void
 rrd_pretty_collapse(int *changed, struct node **n)
 {
 	assert(n != NULL);
-	assert(*n != NULL);
+
+	if (*n == NULL) {
+		return;
+	}
 
 	switch ((*n)->type) {
 	case NODE_ALT:

--- a/src/rrd/pretty_collapse.c
+++ b/src/rrd/pretty_collapse.c
@@ -34,6 +34,9 @@ rrd_pretty_collapse(int *changed, struct node **n)
 		}
 		break;
 
+	case NODE_ALT_SKIPPABLE:
+		break;
+
 	case NODE_SEQ:
 		if (list_count((*n)->u.seq) == 1) {
 			struct node *dead;

--- a/src/rrd/pretty_nested.c
+++ b/src/rrd/pretty_nested.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "../xalloc.h"
+
+#include "pretty.h"
+#include "node.h"
+#include "list.h"
+
+static void
+nested_alt(int *changed, struct node *n)
+{
+	struct list **p;
+	struct list **next;
+
+	/* fold nested alts into this one */
+	for (p = &n->u.alt; *p != NULL; p = next) {
+		struct list **head, **tail;
+		struct list *dead;
+
+		next = &(*p)->next;
+
+		if ((*p)->node == NULL || ((*p)->node->type != NODE_ALT && (*p)->node->type != NODE_ALT_SKIPPABLE)) {
+			continue;
+		}
+
+		dead = *p;
+
+		/* incoming inner list */
+		head = &(*p)->node->u.alt;
+
+		for (tail = head; *tail != NULL; tail = &(*tail)->next)
+			;
+
+		*tail = (*p)->next;
+		(*p)->next = NULL;
+
+		*p = *head;
+		*head = NULL;
+
+		next = p;
+
+		node_free(dead->node);
+		list_free(&dead);
+
+		*changed = 1;
+	}
+}
+
+static void
+nested_seq(int *changed, struct node *n)
+{
+	struct list **p;
+	struct list **next;
+
+	/* fold nested seqs into this one */
+	for (p = &n->u.alt; *p != NULL; p = next) {
+		struct list **head, **tail;
+		struct list *dead;
+
+		next = &(*p)->next;
+
+		if ((*p)->node == NULL || (*p)->node->type != NODE_SEQ) {
+			continue;
+		}
+
+		dead = *p;
+
+		/* incoming inner list */
+		head = &(*p)->node->u.alt;
+
+		for (tail = head; *tail != NULL; tail = &(*tail)->next)
+			;
+
+		*tail = (*p)->next;
+		(*p)->next = NULL;
+
+		*p = *head;
+		*head = NULL;
+
+		next = p;
+
+		node_free(dead->node);
+		list_free(&dead);
+
+		*changed = 1;
+	}
+}
+
+void
+rrd_pretty_nested(int *changed, struct node **n)
+{
+	assert(n != NULL);
+
+	if (*n == NULL) {
+		return;
+	}
+
+	switch ((*n)->type) {
+	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
+		nested_alt(changed, *n);
+		break;
+
+	case NODE_SEQ:
+		nested_seq(changed, *n);
+		break;
+	}
+}
+

--- a/src/rrd/pretty_redundant.c
+++ b/src/rrd/pretty_redundant.c
@@ -54,42 +54,6 @@ redundant_alt(int *changed, struct node *n, struct node **np, int isskippable)
 
 			*changed = 1;
 		}
-	} else {
-		struct list **next;
-
-		/* TODO: factor out to its own transformation */
-		/* fold nested alts into this one */
-		for (p = &n->u.alt; *p != NULL; p = next) {
-			struct list **head, **tail;
-			struct list *dead;
-
-			next = &(*p)->next;
-
-			if ((*p)->node == NULL || (*p)->node->type != NODE_ALT) {
-				continue;
-			}
-
-			dead = *p;
-
-			/* incoming inner list */
-			head = &(*p)->node->u.alt;
-
-			for (tail = head; *tail != NULL; tail = &(*tail)->next)
-				;
-
-			*tail = (*p)->next;
-			(*p)->next = NULL;
-
-			*p = *head;
-			*head = NULL;
-
-			next = p;
-
-			node_free(dead->node);
-			list_free(&dead);
-
-			*changed = 1;
-		}
 	}
 }
 

--- a/src/rrd/pretty_skippable.c
+++ b/src/rrd/pretty_skippable.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "../xalloc.h"
+
+#include "pretty.h"
+#include "node.h"
+#include "list.h"
+
+static void
+skippable_alt(int *changed, struct node *n)
+{
+	struct list **p, **next;
+	struct list *dead;
+
+	for (p = &n->u.alt; *p != NULL; p = next) {
+		next = &(**p).next;
+
+		if ((*p)->node == NULL) {
+			n->type = NODE_ALT_SKIPPABLE;
+
+			dead = *p;
+
+			*p = *next;
+
+			dead->next = NULL;
+			node_free(dead->node);
+			list_free(&dead);
+
+			*changed = 1;
+		}
+	}
+
+	/* TODO: if you're skippable and you contain nothing, have some other transformation remove it */
+	/* TODO: ditto NULL in SEQs, and empty seqs, and empty loops */
+}
+
+void
+rrd_pretty_skippable(int *changed, struct node **n)
+{
+	assert(n != NULL);
+
+	if (*n == NULL) {
+		return;
+	}
+
+	switch ((*n)->type) {
+	case NODE_ALT:
+		skippable_alt(changed, *n);
+		break;
+	}
+}
+

--- a/src/rrd/rrd.h
+++ b/src/rrd/rrd.h
@@ -10,6 +10,6 @@
 struct ast_rule;
 struct node;
 
-struct node *ast_to_rrd(const struct ast_rule *);
+int ast_to_rrd(const struct ast_rule *, struct node **r);
 
 #endif

--- a/src/rrd/transform.c
+++ b/src/rrd/transform.c
@@ -131,9 +131,8 @@ optional_term(const struct ast_term *term, struct node **r)
 	list = NULL;
 
 	list_push(&list, n);
-	list_push(&list, NULL);
 
-	*r = node_create_alt(list);
+	*r = node_create_alt_skippable(list);
 
 	return 1;
 }

--- a/src/rrd/transform.c
+++ b/src/rrd/transform.c
@@ -20,14 +20,16 @@
 #include "node.h"
 #include "list.h"
 
-static struct node *
-transform_term(const struct ast_term *term);
+static int
+transform_term(const struct ast_term *term, struct node **r);
 
-static struct node *
-transform_terms(const struct ast_alt *alt)
+static int
+transform_terms(const struct ast_alt *alt, struct node **r)
 {
 	struct list *list, **tail;
 	const struct ast_term *p;
+
+	assert(r != NULL);
 
 	list = NULL;
 	tail = &list;
@@ -35,8 +37,7 @@ transform_terms(const struct ast_alt *alt)
 	for (p = alt->terms; p != NULL; p = p->next) {
 		struct node *node;
 
-		node = transform_term(p);
-		if (node == NULL) {
+		if (!transform_term(p, &node)) {
 			goto error;
 		}
 
@@ -44,20 +45,24 @@ transform_terms(const struct ast_alt *alt)
 		tail = &(*tail)->next;
 	}
 
-	return node_create_seq(list);
+	*r = node_create_seq(list);
+
+	return 1;
 
 error:
 
 	list_free(&list);
 
-	return NULL;
+	return 0;
 }
 
-static struct node *
-transform_alts(const struct ast_alt *alts)
+static int
+transform_alts(const struct ast_alt *alts, struct node **r)
 {
 	struct list *list, **tail;
 	const struct ast_alt *p;
+
+	assert(r != NULL);
 
 	list = NULL;
 	tail = &list;
@@ -65,8 +70,7 @@ transform_alts(const struct ast_alt *alts)
 	for (p = alts; p != NULL; p = p->next) {
 		struct node *node;
 
-		node = transform_terms(p);
-		if (node == NULL) {
+		if (!transform_terms(p, &node)) {
 			goto error;
 		}
 
@@ -74,128 +78,134 @@ transform_alts(const struct ast_alt *alts)
 		tail = &(*tail)->next;
 	}
 
-	return node_create_alt(list);
+	*r = node_create_alt(list);
+
+	return 1;
 
 error:
 
 	list_free(&list);
 
-	return NULL;
+	return 0;
 }
 
-static struct node *
-single_term(const struct ast_term *term)
+static int
+single_term(const struct ast_term *term, struct node **r)
 {
+	assert(r != NULL);
+
 	switch (term->type) {
 	case TYPE_EMPTY:
-		return node_create_skip();
+		*r = NULL;
+		return 1;
 
 	case TYPE_RULE:
-		return node_create_name(term->u.rule->name);
+		*r = node_create_name(term->u.rule->name);
+		return 1;
 
 	case TYPE_LITERAL:
-		return node_create_literal(term->u.literal);
+		*r = node_create_literal(term->u.literal);
+		return 1;
 
 	case TYPE_TOKEN:
-		return node_create_name(term->u.token);
+		*r = node_create_name(term->u.token);
+		return 1;
 
 	case TYPE_GROUP:
-		return transform_alts(term->u.group);
+		return transform_alts(term->u.group, r);
 	}
 }
 
-static struct node *
-optional_term(const struct ast_term *term)
+static int
+optional_term(const struct ast_term *term, struct node **r)
 {
-	struct node *skip, *n;
+	struct node *n;
 	struct list *list;
 
-	n = single_term(term);
-	if (n == NULL) {
-		return NULL;
-	}
+	assert(r != NULL);
 
-	skip = node_create_skip();
+	if (!single_term(term, &n)) {
+		return 0;
+	}
 
 	list = NULL;
 
 	list_push(&list, n);
-	list_push(&list, skip);
+	list_push(&list, NULL);
 
-	return node_create_alt(list);
+	*r = node_create_alt(list);
+
+	return 1;
 }
 
-static struct node *
-oneormore_term(const struct ast_term *term)
+static int
+oneormore_term(const struct ast_term *term, struct node **r)
+{
+	struct node *n;
+
+	assert(r != NULL);
+
+	if (!single_term(term, &n)) {
+		return 0;
+	}
+
+	*r = node_create_loop(n, NULL);
+
+	return 1;
+}
+
+static int
+zeroormore_term(const struct ast_term *term, struct node **r)
+{
+	struct node *n;
+
+	assert(r != NULL);
+
+	if (!single_term(term, &n)) {
+		return 0;
+	}
+
+	*r = node_create_loop(NULL, n);
+
+	return 1;
+}
+
+static int
+finite_term(const struct ast_term *term, struct node **r)
 {
 	struct node *loop;
-	struct node *skip;
 	struct node *n;
 
-	n = single_term(term);
-	if (n == NULL) {
-		return NULL;
+	assert(r != NULL);
+
+	if (!single_term(term, &n)) {
+		return 0;
 	}
-
-	skip = node_create_skip();
-
-	loop = node_create_loop(n, skip);
-
-	return loop;
-}
-
-static struct node *
-zeroormore_term(const struct ast_term *term)
-{
-	struct node *skip;
-	struct node *n;
-
-	n = single_term(term);
-	if (n == NULL) {
-		return NULL;
-	}
-
-	skip = node_create_skip();
-
-	return node_create_loop(skip, n);
-}
-
-static struct node *
-finite_term(const struct ast_term *term)
-{
-	struct node *skip;
-	struct node *loop;
-	struct node *n;
-
-	n = single_term(term);
-	if (n == NULL) {
-		return NULL;
-	}
-
-	skip = node_create_skip();
 
 	if (term->min > 0) {
-		loop = node_create_loop(n, skip);
+		loop = node_create_loop(n, NULL);
 		loop->u.loop.min = term->min - 1;
 		loop->u.loop.max = term->max - 1;
 	} else {
-		loop = node_create_loop(skip, n);
+		loop = node_create_loop(NULL, n);
 		loop->u.loop.min = term->min;
 		loop->u.loop.max = term->max;
 	}
 
-	return loop;
+	*r = loop;
+
+	return 1;
 }
 
-static struct node *
-transform_term(const struct ast_term *term)
+static int
+transform_term(const struct ast_term *term, struct node **r)
 {
 	size_t i;
 
 	struct {
 		unsigned int min;
 		unsigned int max;
-		struct node *(*f)(const struct ast_term *term);
+		int (*f)(const struct ast_term *term, struct node **r);
 	} a[] = {
 		{ 1, 1, single_term     },
 		{ 0, 1, optional_term   },
@@ -203,20 +213,23 @@ transform_term(const struct ast_term *term)
 		{ 0, 0, zeroormore_term }
 	};
 
+	assert(r != NULL);
+
 	for (i = 0; i < sizeof a / sizeof *a; i++) {
 		if (term->min == a[i].min && term->max == a[i].max) {
-			return a[i].f(term);
+			return a[i].f(term, r);
 		}
 	}
 
-	return finite_term(term);
+	return finite_term(term, r);
 }
 
-struct node *
-ast_to_rrd(const struct ast_rule *ast)
+int
+ast_to_rrd(const struct ast_rule *ast, struct node **r)
 {
 	assert(ast != NULL);
+	assert(r != NULL);
 
-	return transform_alts(ast->alts);
+	return transform_alts(ast->alts, r);
 }
 

--- a/src/rrdot/output.c
+++ b/src/rrdot/output.c
@@ -84,6 +84,7 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 		const struct list *p;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		printf("\t{ rank = same;\n");
 		for (p = node->u.alt; p != NULL; p = p->next) {
 			printf("\t\t\"%s/%p\";\n", prefix, (void *) p->node);
@@ -127,6 +128,10 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 		printf("label = \"ALT\"");
 		break;
 
+	case NODE_ALT_SKIPPABLE:
+		printf("label = \"ALT|&epsilon;\"");
+		break;
+
 	case NODE_SEQ:
 		printf("label = \"SEQ\"");
 		break;
@@ -145,6 +150,7 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 		const struct list *p;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		for (p = node->u.alt; p != NULL; p = p->next) {
 			rrd_print_dot(prefix, node, "", p->node);
 		}

--- a/src/rrdot/output.c
+++ b/src/rrdot/output.c
@@ -76,6 +76,10 @@ static void
 rrd_print_dot(const char *prefix, const void *parent, const char *port,
 	const struct node *node)
 {
+	if (node == NULL) {
+		return;
+	}
+
 	switch (node->type) {
 		const struct list *p;
 
@@ -107,10 +111,6 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 		prefix, (void *) node);
 
 	switch (node->type) {
-	case NODE_SKIP:
-		printf("label = \"&epsilon;\"");
-		break;
-
 	case NODE_LITERAL:
 		printf("style = filled, shape = box, label = \"\\\"");
 		escputs(node->u.literal, stdout);
@@ -178,8 +178,7 @@ rrdot_output(const struct ast_rule *grammar)
 	for (p = grammar; p != NULL; p = p->next) {
 		struct node *rrd;
 
-		rrd = ast_to_rrd(p);
-		if (rrd == NULL) {
+		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
 			return;
 		}

--- a/src/rrdump/output.c
+++ b/src/rrdump/output.c
@@ -37,16 +37,15 @@ static void
 node_walk(FILE *f, const struct node *n, int depth)
 {
 	assert(f != NULL);
-	assert(n != NULL);
+
+	if (n == NULL) {
+		print_indent(f, depth);
+		fprintf(f, "SKIP\n");
+		return;
+	}
 
 	switch (n->type) {
 		const struct list *p;
-
-	case NODE_SKIP:
-		print_indent(f, depth);
-		fprintf(f, "SKIP\n");
-
-		break;
 
 	case NODE_LITERAL:
 		print_indent(f, depth);
@@ -86,13 +85,13 @@ node_walk(FILE *f, const struct node *n, int depth)
 		print_indent(f, depth);
 		fprintf(f, "LOOP:\n");
 
-		if (n->u.loop.forward->type != NODE_SKIP) {
+		if (n->u.loop.forward != NULL) {
 			print_indent(f, depth + 1);
 			fprintf(f, ".forward:\n");
 			node_walk(f, n->u.loop.forward, depth + 2);
 		}
 
-		if (n->u.loop.backward->type != NODE_SKIP) {
+		if (n->u.loop.backward != NULL) {
 			print_indent(f, depth + 1);
 			fprintf(f, ".backward:\n");
 			node_walk(f, n->u.loop.backward, depth + 2);
@@ -110,8 +109,7 @@ rrdump_output(const struct ast_rule *grammar)
 	for (p = grammar; p != NULL; p = p->next) {
 		struct node *rrd;
 
-		rrd = ast_to_rrd(p);
-		if (rrd == NULL) {
+		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
 			return;
 		}

--- a/src/rrdump/output.c
+++ b/src/rrdump/output.c
@@ -60,8 +60,9 @@ node_walk(FILE *f, const struct node *n, int depth)
 		break;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);
-		fprintf(f, "ALT: [\n");
+		fprintf(f, "%s: [\n", n->type == NODE_ALT ? "ALT" : "ALT|SKIP");
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			node_walk(f, p->node, depth + 1);
 		}

--- a/src/rrparcon/output.c
+++ b/src/rrparcon/output.c
@@ -122,16 +122,16 @@ static void
 node_walk(FILE *f, const struct node *n, int depth)
 {
 	assert(f != NULL);
-	assert(n != NULL);
 
-	switch (n->type) {
-		const struct list *p;
-
-	case NODE_SKIP:
+	if (n == NULL) {
 		print_indent(f, depth);
 		fprintf(f, "Nothing()");
 
-		break;
+		return;
+	}
+
+	switch (n->type) {
+		const struct list *p;
 
 	case NODE_LITERAL:
 		print_indent(f, depth);
@@ -192,19 +192,19 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 		if (n->u.loop.max == 1 && n->u.loop.min == 1) {
 			print_comment(f, depth + 1, "(exactly once)");
-			assert(n->u.loop.backward->type == NODE_SKIP);
+			assert(n->u.loop.backward == NULL);
 		} else if (n->u.loop.max == 0 && n->u.loop.min > 0) {
 			print_comment(f, depth + 1, "(at least %d times)", n->u.loop.min);
-			assert(n->u.loop.backward->type == NODE_SKIP);
+			assert(n->u.loop.backward == NULL);
 		} else if (n->u.loop.max > 0 && n->u.loop.min == 0) {
 			print_comment(f, depth + 1, "(up to %d times)", n->u.loop.max);
-			assert(n->u.loop.backward->type == NODE_SKIP);
+			assert(n->u.loop.backward == NULL);
 		} else if (n->u.loop.max > 0 && n->u.loop.min == n->u.loop.max) {
 			print_comment(f, depth + 1, "(%d times)", n->u.loop.max);
-			assert(n->u.loop.backward->type == NODE_SKIP);
+			assert(n->u.loop.backward == NULL);
 		} else if (n->u.loop.max > 1 && n->u.loop.min > 1) {
 			print_comment(f, depth + 1, "(%d-%d times)", n->u.loop.min, n->u.loop.max);
-			assert(n->u.loop.backward->type == NODE_SKIP);
+			assert(n->u.loop.backward == NULL);
 		} else {
 			node_walk(f, n->u.loop.backward, depth);
 		}
@@ -244,8 +244,7 @@ rrparcon_output(const struct ast_rule *grammar)
 	for (p = grammar; p != NULL; p = p->next) {
 		struct node *rrd;
 
-		rrd = ast_to_rrd(p);
-		if (rrd == NULL) {
+		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
 			return;
 		}

--- a/src/rrparcon/output.c
+++ b/src/rrparcon/output.c
@@ -150,8 +150,15 @@ node_walk(FILE *f, const struct node *n, int depth)
 		break;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);
 		fprintf(f, "Or(\n");
+
+		if (n->type == NODE_ALT_SKIPPABLE) {
+			print_indent(f, depth + 1);
+			fprintf(f, "Nothing(),\n");
+		}
+
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			node_walk(f, p->node, depth + 1);
 			if (p->next != NULL) {

--- a/src/rrta/output.c
+++ b/src/rrta/output.c
@@ -108,11 +108,11 @@ normal(const struct list *list)
 		const struct node *a = list->node;
 		const struct node *b = list->next->node;
 
-		if (a->type == NODE_SKIP && b->type == NODE_RULE) {
+		if (a == NULL && b->type == NODE_RULE) {
 			return 1;
 		}
 
-		if (a->type == NODE_RULE && b->type == NODE_SKIP) {
+		if (a->type == NODE_RULE && b == NULL) {
 			return 0;
 		}
 	}
@@ -124,16 +124,16 @@ static void
 node_walk(FILE *f, const struct node *n, int depth)
 {
 	assert(f != NULL);
-	assert(n != NULL);
 
-	switch (n->type) {
-		const struct list *p;
-
-	case NODE_SKIP:
+	if (n == NULL) {
 		print_indent(f, depth);
 		fprintf(f, "Skip()");
 
-		break;
+		return;
+	}
+
+	switch (n->type) {
+		const struct list *p;
 
 	case NODE_LITERAL:
 		print_indent(f, depth);
@@ -202,8 +202,7 @@ rrta_output(const struct ast_rule *grammar)
 	for (p = grammar; p != NULL; p = p->next) {
 		struct node *rrd;
 
-		rrd = ast_to_rrd(p);
-		if (rrd == NULL) {
+		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
 			return;
 		}

--- a/src/rrta/output.c
+++ b/src/rrta/output.c
@@ -152,8 +152,14 @@ node_walk(FILE *f, const struct node *n, int depth)
 		break;
 
 	case NODE_ALT:
+	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);
 		fprintf(f, "Choice(%d,\n", normal(n->u.alt));
+
+		if (n->type == NODE_ALT_SKIPPABLE) {
+			print_indent(f, depth + 1);
+			fprintf(f, "Skip(),\n");
+		}
 
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			node_walk(f, p->node, depth + 1);

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -104,14 +104,13 @@ loop_label(const struct node *loop, char *s)
 static unsigned
 node_walk_dim_w(const struct node *n)
 {
-	assert(n != NULL);
+	if (n == NULL) {
+		return 0;
+	}
 
 	switch (n->type) {
 		const struct list *p;
 		unsigned w;
-
-	case NODE_SKIP:
-		return 0;
 
 	case NODE_LITERAL:
 		return strlen(n->u.literal) + 4;
@@ -167,14 +166,13 @@ node_walk_dim_w(const struct node *n)
 static unsigned
 node_walk_dim_y(const struct node *n)
 {
-	assert(n != NULL);
+	if (n == NULL) {
+		return 0;
+	}
 
 	switch (n->type) {
 		const struct list *p;
 		unsigned y;
-
-	case NODE_SKIP:
-		return 0;
 
 	case NODE_LITERAL:
 		return 0;
@@ -187,7 +185,7 @@ node_walk_dim_y(const struct node *n)
 
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			if (p == n->u.alt) {
-				if (p->node->type == NODE_SKIP && p->next && !p->next->next) {
+				if (p->node == NULL && p->next && !p->next->next) {
 					y = 2 + node_walk_dim_y(p->node) + node_walk_dim_y(p->next->node);
 				} else {
 					y = node_walk_dim_y(p->node);
@@ -223,14 +221,13 @@ node_walk_dim_y(const struct node *n)
 static unsigned
 node_walk_dim_h(const struct node *n)
 {
-	assert(n != NULL);
+	if (n == NULL) {
+		return 1;
+	}
 
 	switch (n->type) {
 		const struct list *p;
 		unsigned h;
-
-	case NODE_SKIP:
-		return 1;
 
 	case NODE_LITERAL:
 		return 1;
@@ -274,7 +271,7 @@ node_walk_dim_h(const struct node *n)
 		h = node_walk_dim_h(n->u.loop.forward) + node_walk_dim_h(n->u.loop.backward) + 1;
 
 		if (loop_label(n, NULL) > 0) {
-			if (n->u.loop.backward->type != NODE_SKIP) {
+			if (n->u.loop.backward != NULL) {
 				h += 2;
 			}
 		}
@@ -323,9 +320,11 @@ justify(struct render_context *ctx, const struct node *n, int space)
 static void
 node_walk_render(const struct node *n, struct render_context *ctx)
 {
-	assert(n != NULL);
-
 	assert(ctx != NULL);
+
+	if (n == NULL) {
+		return;
+	}
 
 	switch (n->type) {
 		const struct list *p;
@@ -462,7 +461,7 @@ node_walk_render(const struct node *n, struct render_context *ctx)
 				int y = ctx->y;
 				char c;
 				ctx->x = x + 1 + (node_walk_dim_w(n) - cw - 2) / 2;
-				if (n->u.loop.backward->type != NODE_SKIP) {
+				if (n->u.loop.backward != NULL) {
 					ctx->y += 2;
 				}
 				/* still less horrible than malloc() */
@@ -481,9 +480,6 @@ node_walk_render(const struct node *n, struct render_context *ctx)
 		}
 
 		break;
-
-	case NODE_SKIP:
-		break;
 	}
 }
 
@@ -495,8 +491,7 @@ rrtext_output(const struct ast_rule *grammar)
 	for (p = grammar; p; p = p->next) {
 		struct node *rrd;
 
-		rrd = ast_to_rrd(p);
-		if (rrd == NULL) {
+		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
 			return;
 		}

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -189,35 +189,31 @@ node_walk_dim_y(const struct node *n)
 
 		/*
 		 * Alt lists hang below the line.
-		 * The height of this node is the height of just the first list item
-		 * because the first item is at the top of the list.
+		 * The y-height of this node is the y-height of just the first list item
+		 * because the first item is at the top of the list, plus the height of
+		 * the skip node above that.
  		 */
 		y = node_walk_dim_y(p->node);
 
 		if (n->type == NODE_ALT_SKIPPABLE) {
-			/* for the skip node above the height of the first item */
 			y += 2;
 		}
 
 		return y;
 
 	case NODE_SEQ:
-		{
-			unsigned top;
+		y = 0;
 
-			top = 0;
+		for (p = n->u.seq; p != NULL; p = p->next) {
+			unsigned z;
 
-			for (p = n->u.seq; p != NULL; p = p->next) {
-				unsigned z;
-
-				z = node_walk_dim_y(p->node);
-				if (z > top) {
-					top = z;
-				}
+			z = node_walk_dim_y(p->node);
+			if (z > y) {
+				y = z;
 			}
-
-			return top;
 		}
+
+		return y;
 
 	case NODE_LOOP:
 		return node_walk_dim_y(n->u.loop.forward);
@@ -249,7 +245,7 @@ node_walk_dim_h(const struct node *n)
 			h += 1 + node_walk_dim_h(p->node);
 		}
 
-		return h - 1 + 2 * (n->type == NODE_ALT_SKIPPABLE);
+		return h + node_walk_dim_y(n) - 1;
 
 	case NODE_SEQ:
 		{

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -346,11 +346,15 @@ node_walk_render(const struct node *n, struct render_context *ctx)
 			y = ctx->y;
 			line = y + node_walk_dim_y(n);
 
-			/* XXX: suspicious. is n->u.alt->node always present? */
-			a_in  = (node_walk_dim_y(n) - node_walk_dim_y(n->u.alt->node)) ? "v" : "^";
-			a_out = (node_walk_dim_y(n) - node_walk_dim_y(n->u.alt->node)) ? "^" : "v";
+			if (n->u.alt->node == NULL) { /* skip */
+				a_in  = node_walk_dim_y(n) ? "v" : "^";
+				a_out = node_walk_dim_y(n) ? "^" : "v";
+			} else {
+				a_in  = "^";
+				a_out = "v";
 
-			ctx->y += node_walk_dim_y(n->u.alt->node);
+				ctx->y += node_walk_dim_y(n);
+			}
 
 			for (p = n->u.alt; p != NULL; p = p->next) {
 				int i, flush = ctx->y == line;

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -241,15 +241,23 @@ node_walk_dim_h(const struct node *n)
 	case NODE_ALT_SKIPPABLE:
 		h = 0;
 
+		assert(n->u.alt != NULL);
+
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			h += 1 + node_walk_dim_h(p->node);
 		}
 
-		return h + node_walk_dim_y(n) - 1;
+		if (n->type == NODE_ALT_SKIPPABLE) {
+ 			h += 2;
+		}
+
+		return h - 1;
 
 	case NODE_SEQ:
 		{
 			unsigned top = 0, bot = 1;
+
+			assert(n->u.seq != NULL);
 
 			for (p = n->u.seq; p != NULL; p = p->next) {
 				unsigned y, z;
@@ -389,11 +397,13 @@ node_walk_render(const struct node *n, struct render_context *ctx)
 				bprintf(ctx, a_in);
 				ctx->y++;
 
-				ctx->x = x;
-				bprintf(ctx, "|");
-				ctx->x = x + node_walk_dim_w(n) - 1;
-				bprintf(ctx, "|");
-				ctx->y++;
+				for (i = 0; i < node_walk_dim_y(n) - 1; i++) {
+					ctx->x = x;
+					bprintf(ctx, "|");
+					ctx->x = x + node_walk_dim_w(n) - 1;
+					bprintf(ctx, "|");
+					ctx->y++;
+				}
 			}
 
 			for (p = n->u.alt; p != NULL; p = p->next) {

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -183,14 +183,11 @@ node_walk_dim_y(const struct node *n)
 	case NODE_ALT:
 		y = 0;
 
-		for (p = n->u.alt; p != NULL; p = p->next) {
-			if (p == n->u.alt) {
-				if (p->node == NULL && p->next && !p->next->next) {
-					y = 2 + node_walk_dim_y(p->node) + node_walk_dim_y(p->next->node);
-				} else {
-					y = node_walk_dim_y(p->node);
-				}
-			}
+		p = n->u.alt;
+		if (p->node == NULL && p->next && !p->next->next) {
+			y = 2 + node_walk_dim_y(p->node) + node_walk_dim_y(p->next->node);
+		} else {
+			y = node_walk_dim_y(p->node);
 		}
 
 		return y;


### PR DESCRIPTION
This PR remove the `NODE_SKIP` node. Skip nodes in arbitrary contexts are now simply `NULL` instead.

Meanwhile the `NODE_ALT` lists have an additional node type for when an alt contains a skip. Previously this was always the first alt (containing `NODE_SKIP`), and now no special handling is needed for the first item.