### PR TITLE
Add prose values for ABNF and ISO EBNF

### DIFF
--- a/src/abnf/lexer.c
+++ b/src/abnf/lexer.c
@@ -290,8 +290,54 @@ z2(struct lx_abnf_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case '>': state = S2; break;
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
 			case '-':
+			case '.':
+			case '/':
 			case '0':
 			case '1':
 			case '2':
@@ -302,6 +348,11 @@ z2(struct lx_abnf_lx *lx)
 			case '7':
 			case '8':
 			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '@':
 			case 'A':
 			case 'B':
 			case 'C':
@@ -328,7 +379,12 @@ z2(struct lx_abnf_lx *lx)
 			case 'X':
 			case 'Y':
 			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
 			case '_':
+			case '`':
 			case 'a':
 			case 'b':
 			case 'c':
@@ -354,8 +410,141 @@ z2(struct lx_abnf_lx *lx)
 			case 'w':
 			case 'x':
 			case 'y':
-			case 'z': state = S1; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case 0x80:
+			case 0x81:
+			case 0x82:
+			case 0x83:
+			case 0x84:
+			case 0x85:
+			case 0x86:
+			case 0x87:
+			case 0x88:
+			case 0x89:
+			case 0x8a:
+			case 0x8b:
+			case 0x8c:
+			case 0x8d:
+			case 0x8e:
+			case 0x8f:
+			case 0x90:
+			case 0x91:
+			case 0x92:
+			case 0x93:
+			case 0x94:
+			case 0x95:
+			case 0x96:
+			case 0x97:
+			case 0x98:
+			case 0x99:
+			case 0x9a:
+			case 0x9b:
+			case 0x9c:
+			case 0x9d:
+			case 0x9e:
+			case 0x9f:
+			case 0xa0:
+			case 0xa1:
+			case 0xa2:
+			case 0xa3:
+			case 0xa4:
+			case 0xa5:
+			case 0xa6:
+			case 0xa7:
+			case 0xa8:
+			case 0xa9:
+			case 0xaa:
+			case 0xab:
+			case 0xac:
+			case 0xad:
+			case 0xae:
+			case 0xaf:
+			case 0xb0:
+			case 0xb1:
+			case 0xb2:
+			case 0xb3:
+			case 0xb4:
+			case 0xb5:
+			case 0xb6:
+			case 0xb7:
+			case 0xb8:
+			case 0xb9:
+			case 0xba:
+			case 0xbb:
+			case 0xbc:
+			case 0xbd:
+			case 0xbe:
+			case 0xbf:
+			case 0xc0:
+			case 0xc1:
+			case 0xc2:
+			case 0xc3:
+			case 0xc4:
+			case 0xc5:
+			case 0xc6:
+			case 0xc7:
+			case 0xc8:
+			case 0xc9:
+			case 0xca:
+			case 0xcb:
+			case 0xcc:
+			case 0xcd:
+			case 0xce:
+			case 0xcf:
+			case 0xd0:
+			case 0xd1:
+			case 0xd2:
+			case 0xd3:
+			case 0xd4:
+			case 0xd5:
+			case 0xd6:
+			case 0xd7:
+			case 0xd8:
+			case 0xd9:
+			case 0xda:
+			case 0xdb:
+			case 0xdc:
+			case 0xdd:
+			case 0xde:
+			case 0xdf:
+			case 0xe0:
+			case 0xe1:
+			case 0xe2:
+			case 0xe3:
+			case 0xe4:
+			case 0xe5:
+			case 0xe6:
+			case 0xe7:
+			case 0xe8:
+			case 0xe9:
+			case 0xea:
+			case 0xeb:
+			case 0xec:
+			case 0xed:
+			case 0xee:
+			case 0xef:
+			case 0xf0:
+			case 0xf1:
+			case 0xf2:
+			case 0xf3:
+			case 0xf4:
+			case 0xf5:
+			case 0xf6:
+			case 0xf7:
+			case 0xf8:
+			case 0xf9:
+			case 0xfa:
+			case 0xfb:
+			case 0xfc:
+			case 0xfd:
+			case 0xfe:
+			case 0xff: state = S1; break;
+			case '>': state = S2; break;
 			}
 			break;
 
@@ -363,7 +552,7 @@ z2(struct lx_abnf_lx *lx)
 			lx_abnf_ungetc(lx, c); return TOK_CHAR;
 
 		case S2: /* e.g. ">" */
-			lx_abnf_ungetc(lx, c); return lx->z = z4, TOK_NAME;
+			lx_abnf_ungetc(lx, c); return lx->z = z4, TOK_PROSE;
 
 		default:
 			; /* unreached */
@@ -381,7 +570,7 @@ z2(struct lx_abnf_lx *lx)
 	switch (state) {
 	case NONE: return TOK_EOF;
 	case S1: return TOK_CHAR;
-	case S2: return TOK_NAME;
+	case S2: return TOK_PROSE;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -485,28 +674,16 @@ z4(struct lx_abnf_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case '<': state = S11; break;
+			case '\n': state = S2; break;
 			case '\t':
 			case '\v':
 			case '\f':
 			case '\r':
 			case ' ': state = S1; break;
-			case ';': state = S10; break;
-			case '"': state = S3; break;
-			case '%': state = S4; break;
-			case '=': state = S12; break;
 			case '(': state = S5; break;
-			case '\n': state = S2; break;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S9; break;
+			case ';': state = S10; break;
+			case '<': state = S11; break;
+			case '=': state = S12; break;
 			case 'A':
 			case 'B':
 			case 'C':
@@ -559,11 +736,23 @@ z4(struct lx_abnf_lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S13; break;
-			case '/': state = S8; break;
-			case '*': state = S7; break;
-			case ')': state = S6; break;
 			case '[': state = S14; break;
+			case ')': state = S6; break;
 			case ']': state = S15; break;
+			case '*': state = S7; break;
+			case '"': state = S3; break;
+			case '/': state = S8; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S9; break;
+			case '%': state = S4; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -581,7 +770,7 @@ z4(struct lx_abnf_lx *lx)
 
 		case S2: /* e.g. "\n" */
 			switch ((unsigned char) c) {
-			case '\n': state = S17; break;
+			case '\n': state = S16; break;
 			default:  lx_abnf_ungetc(lx, c); return lx->z(lx);
 			}
 			break;
@@ -591,11 +780,11 @@ z4(struct lx_abnf_lx *lx)
 
 		case S4: /* e.g. "%" */
 			switch ((unsigned char) c) {
+			case 's': state = S21; break;
+			case 'x': state = S22; break;
 			case 'b': state = S18; break;
 			case 'd': state = S19; break;
 			case 'i': state = S20; break;
-			case 's': state = S21; break;
-			case 'x': state = S22; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -636,7 +825,7 @@ z4(struct lx_abnf_lx *lx)
 
 		case S12: /* e.g. "=" */
 			switch ((unsigned char) c) {
-			case '/': state = S16; break;
+			case '/': state = S17; break;
 			default:  lx_abnf_ungetc(lx, c); return TOK_EQUALS;
 			}
 			break;
@@ -716,16 +905,16 @@ z4(struct lx_abnf_lx *lx)
 		case S15: /* e.g. "]" */
 			lx_abnf_ungetc(lx, c); return TOK_ENDOPT;
 
-		case S16: /* e.g. "=\057" */
-			lx_abnf_ungetc(lx, c); return TOK_ALTINC;
-
-		case S17: /* e.g. "\n\n" */
+		case S16: /* e.g. "\n\n" */
 			lx_abnf_ungetc(lx, c); return TOK_SEP;
+
+		case S17: /* e.g. "=\057" */
+			lx_abnf_ungetc(lx, c); return TOK_ALTINC;
 
 		case S18: /* e.g. "%b" */
 			switch ((unsigned char) c) {
 			case '0':
-			case '1': state = S34; break;
+			case '1': state = S24; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -783,7 +972,7 @@ z4(struct lx_abnf_lx *lx)
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f': state = S24; break;
+			case 'f': state = S26; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -791,33 +980,13 @@ z4(struct lx_abnf_lx *lx)
 		case S23: /* e.g. "%s\"" */
 			lx_abnf_ungetc(lx, c); return lx->z = z0, lx->z(lx);
 
-		case S24: /* e.g. "%xa" */
+		case S24: /* e.g. "%b0" */
 			switch ((unsigned char) c) {
 			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': break;
-			case '-': state = S30; break;
-			case '.': state = S31; break;
-			default:  lx_abnf_ungetc(lx, c); return TOK_HEXSTR;
+			case '1': break;
+			case '-': state = S31; break;
+			case '.': state = S32; break;
+			default:  lx_abnf_ungetc(lx, c); return TOK_BINSTR;
 			}
 			break;
 
@@ -833,78 +1002,13 @@ z4(struct lx_abnf_lx *lx)
 			case '7':
 			case '8':
 			case '9': break;
-			case '-': state = S26; break;
-			case '.': state = S27; break;
+			case '-': state = S35; break;
+			case '.': state = S36; break;
 			default:  lx_abnf_ungetc(lx, c); return TOK_DECSTR;
 			}
 			break;
 
-		case S26: /* e.g. "%d0-" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S28; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S27: /* e.g. "%d0." */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S29; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S28: /* e.g. "%d0-0" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': break;
-			default:  lx_abnf_ungetc(lx, c); return TOK_DECRANGE;
-			}
-			break;
-
-		case S29: /* e.g. "%d0.0" */
-			switch ((unsigned char) c) {
-			case '.': state = S27; break;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': break;
-			default:  lx_abnf_ungetc(lx, c); return TOK_DECSTR;
-			}
-			break;
-
-		case S30: /* e.g. "%xa-" */
+		case S26: /* e.g. "%xa" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -927,12 +1031,14 @@ z4(struct lx_abnf_lx *lx)
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f': state = S33; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			case 'f': break;
+			case '-': state = S27; break;
+			case '.': state = S28; break;
+			default:  lx_abnf_ungetc(lx, c); return TOK_HEXSTR;
 			}
 			break;
 
-		case S31: /* e.g. "%xa." */
+		case S27: /* e.g. "%xa-" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -955,14 +1061,42 @@ z4(struct lx_abnf_lx *lx)
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f': state = S32; break;
+			case 'f': state = S30; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S32: /* e.g. "%xa.a" */
+		case S28: /* e.g. "%xa." */
 			switch ((unsigned char) c) {
-			case '.': state = S31; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S29; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S29: /* e.g. "%xa.a" */
+			switch ((unsigned char) c) {
+			case '.': state = S28; break;
 			case '0':
 			case '1':
 			case '2':
@@ -989,7 +1123,7 @@ z4(struct lx_abnf_lx *lx)
 			}
 			break;
 
-		case S33: /* e.g. "%xa-a" */
+		case S30: /* e.g. "%xa-a" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1017,46 +1151,101 @@ z4(struct lx_abnf_lx *lx)
 			}
 			break;
 
-		case S34: /* e.g. "%b0" */
+		case S31: /* e.g. "%b0-" */
 			switch ((unsigned char) c) {
 			case '0':
-			case '1': break;
-			case '-': state = S35; break;
-			case '.': state = S36; break;
-			default:  lx_abnf_ungetc(lx, c); return TOK_BINSTR;
-			}
-			break;
-
-		case S35: /* e.g. "%b0-" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1': state = S38; break;
+			case '1': state = S33; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S36: /* e.g. "%b0." */
+		case S32: /* e.g. "%b0." */
 			switch ((unsigned char) c) {
 			case '0':
-			case '1': state = S37; break;
+			case '1': state = S34; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S37: /* e.g. "%b0.0" */
-			switch ((unsigned char) c) {
-			case '.': state = S36; break;
-			case '0':
-			case '1': break;
-			default:  lx_abnf_ungetc(lx, c); return TOK_BINSTR;
-			}
-			break;
-
-		case S38: /* e.g. "%b0-0" */
+		case S33: /* e.g. "%b0-0" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1': break;
 			default:  lx_abnf_ungetc(lx, c); return TOK_BINRANGE;
+			}
+			break;
+
+		case S34: /* e.g. "%b0.0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1': break;
+			case '.': state = S32; break;
+			default:  lx_abnf_ungetc(lx, c); return TOK_BINSTR;
+			}
+			break;
+
+		case S35: /* e.g. "%d0-" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S37; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S36: /* e.g. "%d0." */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S38; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S37: /* e.g. "%d0-0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': break;
+			default:  lx_abnf_ungetc(lx, c); return TOK_DECRANGE;
+			}
+			break;
+
+		case S38: /* e.g. "%d0.0" */
+			switch ((unsigned char) c) {
+			case '.': state = S36; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': break;
+			default:  lx_abnf_ungetc(lx, c); return TOK_DECSTR;
 			}
 			break;
 
@@ -1103,18 +1292,18 @@ z4(struct lx_abnf_lx *lx)
 	case S13: return TOK_IDENT;
 	case S14: return TOK_STARTOPT;
 	case S15: return TOK_ENDOPT;
-	case S16: return TOK_ALTINC;
-	case S17: return TOK_SEP;
+	case S16: return TOK_SEP;
+	case S17: return TOK_ALTINC;
 	case S23: return TOK_EOF;
-	case S24: return TOK_HEXSTR;
+	case S24: return TOK_BINSTR;
 	case S25: return TOK_DECSTR;
-	case S28: return TOK_DECRANGE;
-	case S29: return TOK_DECSTR;
-	case S32: return TOK_HEXSTR;
-	case S33: return TOK_HEXRANGE;
+	case S26: return TOK_HEXSTR;
+	case S29: return TOK_HEXSTR;
+	case S30: return TOK_HEXRANGE;
+	case S33: return TOK_BINRANGE;
 	case S34: return TOK_BINSTR;
-	case S37: return TOK_BINSTR;
-	case S38: return TOK_BINRANGE;
+	case S37: return TOK_DECRANGE;
+	case S38: return TOK_DECSTR;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1142,7 +1331,7 @@ lx_abnf_name(enum lx_abnf_token t)
 	case TOK_EQUALS: return "EQUALS";
 	case TOK_SEP: return "SEP";
 	case TOK_CHAR: return "CHAR";
-	case TOK_NAME: return "NAME";
+	case TOK_PROSE: return "PROSE";
 	case TOK_IDENT: return "IDENT";
 	case TOK_EOF:     return "EOF";
 	case TOK_ERROR:   return "ERROR";
@@ -1173,7 +1362,7 @@ lx_abnf_example(enum lx_abnf_token (*z)(struct lx_abnf_lx *), enum lx_abnf_token
 	if (z == z2) {
 		switch (t) {
 		case TOK_CHAR: return "a";
-		case TOK_NAME: return ">";
+		case TOK_PROSE: return ">";
 		default: goto error;
 		}
 	} else

--- a/src/abnf/lexer.h
+++ b/src/abnf/lexer.h
@@ -23,7 +23,7 @@ enum lx_abnf_token {
 	TOK_EQUALS,
 	TOK_SEP,
 	TOK_CHAR,
-	TOK_NAME,
+	TOK_PROSE,
 	TOK_IDENT,
 	TOK_EOF,
 	TOK_ERROR,

--- a/src/abnf/lexer.lx
+++ b/src/abnf/lexer.lx
@@ -14,9 +14,16 @@
 # case insenstive!
 /[a-z][\-a-z0-9]*/i -> $ident;
 
+# 2.1. says <xyz> is _typically_ prose, but could also be a rule name.
+# In this implementation, we do not support the rule form, and angled
+# brackets always mean prose.
 # case insenstive!
-"<" .. ">" -> $name {
-	/[\-a-z0-9_]/i -> $char;
+#"<" .. ">" -> $name {
+#	/[\-a-z0-9_]/i -> $char;
+#}
+
+'<' .. '>' -> $prose {
+	/[^?]/ -> $char;
 }
 
 # 2.2. Rule form

--- a/src/abnf/parser.c
+++ b/src/abnf/parser.c
@@ -201,6 +201,16 @@
 		return 0;
 	}
 
+	static const char *
+	ltrim(const char *s)
+	{
+		while (isspace((unsigned char) *s)) {
+			s++;
+		}
+
+		return s;
+	}
+
 	static void
 	rtrim(char *s)
 	{
@@ -211,6 +221,13 @@
 		while (p >= s && isspace((unsigned char) *p)) {
 			*p-- = '\0';
 		}
+	}
+
+	static const char *
+	trim(char *s)
+	{
+		rtrim(s);
+		return ltrim(s);
 	}
 
 	static void
@@ -242,7 +259,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 246 "src/abnf/parser.c"
+#line 263 "src/abnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -259,13 +276,13 @@ static void prod_list_Hof_Halts(lex_state, act_state, map_alt *);
 static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
-static void prod_84(lex_state, act_state, map_count *);
-static void prod_99(lex_state, act_state, map_rule *);
-static void prod_100(lex_state, act_state, map_term *, map_alt *);
-static void prod_101(lex_state, act_state, map_term *);
-static void prod_103(lex_state, act_state, map_count *, map_term *);
-static void prod_104(lex_state, act_state, map_term *);
+static void prod_86(lex_state, act_state, map_count *);
+static void prod_100(lex_state, act_state, map_rule *);
+static void prod_101(lex_state, act_state, map_term *, map_alt *);
+static void prod_102(lex_state, act_state, map_term *);
+static void prod_104(lex_state, act_state, map_count *, map_term *);
 static void prod_factor_C_Celement(lex_state, act_state, map_term *);
+static void prod_105(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -280,20 +297,20 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 	switch (CURRENT_TERMINAL) {
 	case (TOK_COUNT):
 		{
-			map_count ZI102;
+			map_count ZI103;
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 310 "src/parser.act"
+#line 327 "src/parser.act"
 
-		ZI102 = strtoul(lex_state->buf.a, NULL, 10);
+		ZI103 = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 293 "src/abnf/parser.c"
+#line 310 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
-			prod_103 (lex_state, act_state, &ZI102, &ZIt);
+			prod_104 (lex_state, act_state, &ZI103, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -314,12 +331,12 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 481 "src/parser.act"
+#line 498 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 323 "src/abnf/parser.c"
+#line 340 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			switch (CURRENT_TERMINAL) {
@@ -331,28 +348,28 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 339 "src/abnf/parser.c"
+#line 356 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 351 "src/abnf/parser.c"
+#line 368 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
 		break;
-	case (TOK_STARTGROUP): case (TOK_NAME): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL):
+	case (TOK_STARTGROUP): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE):
 	case (TOK_CHAR): case (TOK_IDENT): case (TOK_BINSTR): case (TOK_DECSTR):
 	case (TOK_HEXSTR): case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
@@ -366,21 +383,21 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 	case (TOK_REP):
 		{
 			map_count ZImin;
-			map_count ZI83;
+			map_count ZI85;
 			map_count ZImax;
 
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 476 "src/parser.act"
+#line 493 "src/parser.act"
 
 		(ZImin) = 0;
-		(ZI83) = 0;
+		(ZI85) = 0;
 	
-#line 380 "src/abnf/parser.c"
+#line 397 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			ADVANCE_LEXER;
-			prod_84 (lex_state, act_state, &ZImax);
+			prod_86 (lex_state, act_state, &ZImax);
 			prod_factor_C_Celement (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -388,14 +405,14 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 399 "src/abnf/parser.c"
+#line 416 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -439,21 +456,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 587 "src/parser.act"
+#line 614 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 447 "src/abnf/parser.c"
+#line 464 "src/abnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 634 "src/parser.act"
+#line 661 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 457 "src/abnf/parser.c"
+#line 474 "src/abnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -471,7 +488,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_101 (lex_state, act_state, &ZIl);
+		prod_102 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -495,7 +512,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_99 (lex_state, act_state, &ZIl);
+		prod_100 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -521,7 +538,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_100 (lex_state, act_state, &ZIt, &ZIl);
+		prod_101 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -544,20 +561,20 @@ ZL2_body:;
 		{
 			map_char ZIc;
 
-			/* BEGINNING OF INLINE: 73 */
+			/* BEGINNING OF INLINE: 75 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 289 "src/parser.act"
+#line 306 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 561 "src/abnf/parser.c"
+#line 578 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -567,15 +584,15 @@ ZL2_body:;
 					ADVANCE_LEXER;
 				}
 			}
-			/* END OF INLINE: 73 */
+			/* END OF INLINE: 75 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 448 "src/parser.act"
+#line 465 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 579 "src/abnf/parser.c"
+#line 596 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -606,7 +623,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 302 "src/parser.act"
+#line 319 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -623,13 +640,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 627 "src/abnf/parser.c"
+#line 644 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 525 "src/parser.act"
+#line 542 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -647,15 +664,15 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 651 "src/abnf/parser.c"
+#line 668 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
 		break;
-	case (TOK_NAME): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_CHAR):
+	case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR):
 		{
 			prod_body (lex_state, act_state);
-			prod_104 (lex_state, act_state, &ZIt);
+			prod_105 (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -674,7 +691,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: BINRANGE */
 						{
-#line 395 "src/parser.act"
+#line 412 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, &ZIm, &ZIn,  2)) {
 			if (errno == ERANGE) {
@@ -686,7 +703,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 690 "src/abnf/parser.c"
+#line 707 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: BINRANGE */
 						ADVANCE_LEXER;
@@ -696,7 +713,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: DECRANGE */
 						{
-#line 419 "src/parser.act"
+#line 436 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, &ZIm, &ZIn, 10)) {
 			if (errno == ERANGE) {
@@ -708,7 +725,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 712 "src/abnf/parser.c"
+#line 729 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: DECRANGE */
 						ADVANCE_LEXER;
@@ -718,7 +735,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: HEXRANGE */
 						{
-#line 431 "src/parser.act"
+#line 448 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, &ZIm, &ZIn, 16)) {
 			if (errno == ERANGE) {
@@ -730,7 +747,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 734 "src/abnf/parser.c"
+#line 751 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: HEXRANGE */
 						ADVANCE_LEXER;
@@ -743,7 +760,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			/* END OF INLINE: escrange */
 			/* BEGINNING OF ACTION: make-range-term */
 			{
-#line 563 "src/parser.act"
+#line 590 "src/parser.act"
 
 		struct ast_alt *a;
 		int i;
@@ -763,7 +780,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_group_term(a);
 	
-#line 767 "src/abnf/parser.c"
+#line 784 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-range-term */
 		}
@@ -779,7 +796,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: BINSTR */
 						{
-#line 315 "src/parser.act"
+#line 332 "src/parser.act"
 
 		ZIs = xstrdup(lex_state->buf.a);
 		if (ZIs == NULL) {
@@ -799,7 +816,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 803 "src/abnf/parser.c"
+#line 820 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: BINSTR */
 						ADVANCE_LEXER;
@@ -809,7 +826,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: DECSTR */
 						{
-#line 355 "src/parser.act"
+#line 372 "src/parser.act"
 
 		ZIs = xstrdup(lex_state->buf.a);
 		if (ZIs == NULL) {
@@ -829,7 +846,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 833 "src/abnf/parser.c"
+#line 850 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: DECSTR */
 						ADVANCE_LEXER;
@@ -839,7 +856,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: HEXSTR */
 						{
-#line 375 "src/parser.act"
+#line 392 "src/parser.act"
 
 		ZIs = xstrdup(lex_state->buf.a);
 		if (ZIs == NULL) {
@@ -859,7 +876,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 863 "src/abnf/parser.c"
+#line 880 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: HEXSTR */
 						ADVANCE_LEXER;
@@ -872,11 +889,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			/* END OF INLINE: escstr */
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 546 "src/parser.act"
+#line 563 "src/parser.act"
 
 		(ZIt) = ast_make_literal_term((ZIs), 0);
 	
-#line 880 "src/abnf/parser.c"
+#line 897 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -905,14 +922,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 	{
 		map_string ZIs;
 
-		/* BEGINNING OF INLINE: 92 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_IDENT):
-				{
-					/* BEGINNING OF EXTRACT: IDENT */
-					{
-#line 302 "src/parser.act"
+		switch (CURRENT_TERMINAL) {
+		case (TOK_IDENT):
+			/* BEGINNING OF EXTRACT: IDENT */
+			{
+#line 319 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -929,89 +943,48 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 933 "src/abnf/parser.c"
-					}
-					/* END OF EXTRACT: IDENT */
-					ADVANCE_LEXER;
-				}
-				break;
-			case (TOK_NAME): case (TOK_CHAR):
-				{
-					prod_body (lex_state, act_state);
-					switch (CURRENT_TERMINAL) {
-					case (TOK_NAME):
-						break;
-					case (ERROR_TERMINAL):
-						RESTORE_LEXER;
-						goto ZL1;
-					default:
-						goto ZL1;
-					}
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: pattern-buffer */
-					{
-#line 460 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 972 "src/abnf/parser.c"
-					}
-					/* END OF ACTION: pattern-buffer */
-				}
-				break;
-			default:
-				goto ZL1;
+#line 947 "src/abnf/parser.c"
 			}
+			/* END OF EXTRACT: IDENT */
+			break;
+		default:
+			goto ZL1;
 		}
-		/* END OF INLINE: 92 */
-		/* BEGINNING OF INLINE: 93 */
+		ADVANCE_LEXER;
+		/* BEGINNING OF INLINE: 94 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EQUALS):
 				{
 					map_alt ZIa;
 
-					/* BEGINNING OF INLINE: 94 */
+					/* BEGINNING OF INLINE: 95 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
 							case (TOK_EQUALS):
 								break;
 							default:
-								goto ZL5;
+								goto ZL4;
 							}
 							ADVANCE_LEXER;
 						}
-						goto ZL4;
-					ZL5:;
+						goto ZL3;
+					ZL4:;
 						{
 							/* BEGINNING OF ACTION: err-expected-equals */
 							{
-#line 646 "src/parser.act"
+#line 673 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 1009 "src/abnf/parser.c"
+#line 982 "src/abnf/parser.c"
 							}
 							/* END OF ACTION: err-expected-equals */
 						}
-					ZL4:;
+					ZL3:;
 					}
-					/* END OF INLINE: 94 */
+					/* END OF INLINE: 95 */
 					prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
@@ -1019,11 +992,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					}
 					/* BEGINNING OF ACTION: make-rule */
 					{
-#line 583 "src/parser.act"
+#line 610 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 1027 "src/abnf/parser.c"
+#line 1000 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: make-rule */
 				}
@@ -1033,42 +1006,42 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					map_rule ZIl;
 					map_alt ZIa;
 
-					/* BEGINNING OF INLINE: 95 */
+					/* BEGINNING OF INLINE: 96 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
 							case (TOK_ALTINC):
 								break;
 							default:
-								goto ZL7;
+								goto ZL6;
 							}
 							ADVANCE_LEXER;
 						}
-						goto ZL6;
-					ZL7:;
+						goto ZL5;
+					ZL6:;
 						{
 							/* BEGINNING OF ACTION: err-expected-equals */
 							{
-#line 646 "src/parser.act"
+#line 673 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 1057 "src/abnf/parser.c"
+#line 1030 "src/abnf/parser.c"
 							}
 							/* END OF ACTION: err-expected-equals */
 						}
-					ZL6:;
+					ZL5:;
 					}
-					/* END OF INLINE: 95 */
+					/* END OF INLINE: 96 */
 					/* BEGINNING OF ACTION: current-rules */
 					{
-#line 615 "src/parser.act"
+#line 642 "src/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		(ZIl) = NULL;
 		goto ZL1;
 	
-#line 1072 "src/abnf/parser.c"
+#line 1045 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: current-rules */
 					prod_list_Hof_Halts (lex_state, act_state, &ZIa);
@@ -1078,23 +1051,23 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					}
 					/* BEGINNING OF ACTION: find-rule */
 					{
-#line 620 "src/parser.act"
+#line 647 "src/parser.act"
 
 		assert((ZIs) != NULL);
 
 		(ZIr) = ast_find_rule((ZIl), (ZIs));
 	
-#line 1088 "src/abnf/parser.c"
+#line 1061 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: find-rule */
 					/* BEGINNING OF ACTION: add-alts */
 					{
-#line 627 "src/parser.act"
+#line 654 "src/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		goto ZL1;
 	
-#line 1098 "src/abnf/parser.c"
+#line 1071 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: add-alts */
 				}
@@ -1103,8 +1076,8 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 93 */
-		/* BEGINNING OF INLINE: 96 */
+		/* END OF INLINE: 94 */
+		/* BEGINNING OF INLINE: 97 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EOF):
@@ -1118,24 +1091,24 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 				}
 				break;
 			default:
-				goto ZL9;
+				goto ZL8;
 			}
-			goto ZL8;
-		ZL9:;
+			goto ZL7;
+		ZL8:;
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 642 "src/parser.act"
+#line 669 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 1133 "src/abnf/parser.c"
+#line 1106 "src/abnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
-		ZL8:;
+		ZL7:;
 		}
-		/* END OF INLINE: 96 */
+		/* END OF INLINE: 97 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1146,7 +1119,7 @@ ZL0:;
 }
 
 static void
-prod_84(lex_state lex_state, act_state act_state, map_count *ZOmax)
+prod_86(lex_state lex_state, act_state act_state, map_count *ZOmax)
 {
 	map_count ZImax;
 
@@ -1155,12 +1128,12 @@ prod_84(lex_state lex_state, act_state act_state, map_count *ZOmax)
 		{
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 310 "src/parser.act"
+#line 327 "src/parser.act"
 
 		ZImax = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 1164 "src/abnf/parser.c"
+#line 1137 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -1168,16 +1141,16 @@ prod_84(lex_state lex_state, act_state act_state, map_count *ZOmax)
 		break;
 	default:
 		{
-			map_count ZI86;
+			map_count ZI88;
 
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 476 "src/parser.act"
+#line 493 "src/parser.act"
 
-		(ZI86) = 0;
+		(ZI88) = 0;
 		(ZImax) = 0;
 	
-#line 1181 "src/abnf/parser.c"
+#line 1154 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 		}
@@ -1189,10 +1162,10 @@ prod_84(lex_state lex_state, act_state act_state, map_count *ZOmax)
 }
 
 static void
-prod_99(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_100(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
-	case (TOK_NAME): case (TOK_CHAR): case (TOK_IDENT):
+	case (TOK_IDENT):
 		{
 			map_rule ZIr;
 
@@ -1203,7 +1176,7 @@ prod_99(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 602 "src/parser.act"
+#line 629 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -1215,7 +1188,7 @@ prod_99(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 1219 "src/abnf/parser.c"
+#line 1192 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -1232,7 +1205,7 @@ ZL1:;
 }
 
 static void
-prod_100(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_101(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -1241,7 +1214,7 @@ prod_100(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 89 */
+			/* BEGINNING OF INLINE: 91 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -1257,17 +1230,17 @@ prod_100(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 638 "src/parser.act"
+#line 665 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 1265 "src/abnf/parser.c"
+#line 1238 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 89 */
+			/* END OF INLINE: 91 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1275,21 +1248,21 @@ prod_100(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1283 "src/abnf/parser.c"
+#line 1256 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 597 "src/parser.act"
+#line 624 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1293 "src/abnf/parser.c"
+#line 1266 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1298,11 +1271,11 @@ prod_100(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1306 "src/abnf/parser.c"
+#line 1279 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1319,11 +1292,11 @@ ZL0:;
 }
 
 static void
-prod_101(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_102(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
-	case (TOK_REP): case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_NAME):
-	case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_CHAR): case (TOK_IDENT):
+	case (TOK_REP): case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_CI__LITERAL):
+	case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR): case (TOK_IDENT):
 	case (TOK_COUNT): case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
 	case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
@@ -1336,12 +1309,12 @@ prod_101(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 592 "src/parser.act"
+#line 619 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1345 "src/abnf/parser.c"
+#line 1318 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1358,7 +1331,7 @@ ZL1:;
 }
 
 static void
-prod_103(lex_state lex_state, act_state act_state, map_count *ZI102, map_term *ZOt)
+prod_104(lex_state lex_state, act_state act_state, map_count *ZI103, map_term *ZOt)
 {
 	map_term ZIt;
 
@@ -1368,7 +1341,7 @@ prod_103(lex_state lex_state, act_state act_state, map_count *ZI102, map_term *Z
 			map_count ZImax;
 
 			ADVANCE_LEXER;
-			prod_84 (lex_state, act_state, &ZImax);
+			prod_86 (lex_state, act_state, &ZImax);
 			prod_factor_C_Celement (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1376,19 +1349,19 @@ prod_103(lex_state lex_state, act_state act_state, map_count *ZI102, map_term *Z
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
-		assert((ZImax) >= (*ZI102) || !(ZImax));
+		assert((ZImax) >= (*ZI103) || !(ZImax));
 
-		(ZIt)->min = (*ZI102);
+		(ZIt)->min = (*ZI103);
 		(ZIt)->max = (ZImax);
 	
-#line 1387 "src/abnf/parser.c"
+#line 1360 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
 		break;
-	case (TOK_STARTGROUP): case (TOK_NAME): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL):
+	case (TOK_STARTGROUP): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE):
 	case (TOK_CHAR): case (TOK_IDENT): case (TOK_BINSTR): case (TOK_DECSTR):
 	case (TOK_HEXSTR): case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
@@ -1399,173 +1372,16 @@ prod_103(lex_state lex_state, act_state act_state, map_count *ZI102, map_term *Z
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
-		assert((*ZI102) >= (*ZI102) || !(*ZI102));
+		assert((*ZI103) >= (*ZI103) || !(*ZI103));
 
-		(ZIt)->min = (*ZI102);
-		(ZIt)->max = (*ZI102);
+		(ZIt)->min = (*ZI103);
+		(ZIt)->max = (*ZI103);
 	
-#line 1410 "src/abnf/parser.c"
+#line 1383 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOt = ZIt;
-}
-
-static void
-prod_104(lex_state lex_state, act_state act_state, map_term *ZOt)
-{
-	map_term ZIt;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CI__LITERAL):
-		{
-			map_string ZIs;
-
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
-			{
-#line 460 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 1459 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: pattern-buffer */
-			/* BEGINNING OF ACTION: make-ci-literal-term */
-			{
-#line 538 "src/parser.act"
-
-		char *p;
-
-		/* normalise case-insensitive strings for aesthetic reasons only */
-		for (p = (ZIs); *p != '\0'; p++) {
-			*p = tolower((unsigned char) *p);
-		}
-
-		(ZIt) = ast_make_literal_term((ZIs), 1);
-	
-#line 1475 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: make-ci-literal-term */
-		}
-		break;
-	case (TOK_CS__LITERAL):
-		{
-			map_string ZIs;
-
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
-			{
-#line 460 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 1505 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: pattern-buffer */
-			/* BEGINNING OF ACTION: make-cs-literal-term */
-			{
-#line 546 "src/parser.act"
-
-		(ZIt) = ast_make_literal_term((ZIs), 0);
-	
-#line 1514 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: make-cs-literal-term */
-		}
-		break;
-	case (TOK_NAME):
-		{
-			map_string ZIs;
-
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
-			{
-#line 460 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 1544 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: pattern-buffer */
-			/* BEGINNING OF ACTION: make-rule-term */
-			{
-#line 525 "src/parser.act"
-
-		struct ast_rule *r;
-
-		/*
-		 * Regardless of whether a rule exists (yet) by this name, we make
-		 * a placeholder rule just so that we have an ast_rule struct
-		 * at which to point. This saves passing the grammar around, which
-		 * keeps the rule-building productions simpler.
-		 */
-		r = ast_make_rule((ZIs), NULL);
-		if (r == NULL) {
-			perror("ast_make_rule");
-			goto ZL1;
-		}
-
-		(ZIt) = ast_make_rule_term(r);
-	
-#line 1567 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: make-rule-term */
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -1605,16 +1421,16 @@ prod_factor_C_Celement(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 1613 "src/abnf/parser.c"
+#line 1429 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
 		break;
-	case (TOK_NAME): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_CHAR):
+	case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR):
 	case (TOK_IDENT): case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
 	case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
@@ -1638,9 +1454,158 @@ ZL0:;
 	*ZOt = ZIt;
 }
 
+static void
+prod_105(lex_state lex_state, act_state act_state, map_term *ZOt)
+{
+	map_term ZIt;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CI__LITERAL):
+		{
+			map_string ZIs;
+
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: pattern-buffer */
+			{
+#line 477 "src/parser.act"
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		/*
+		 * Note we strdup() here because the grammar permits adjacent patterns,
+		 * and so the pattern buffer will be overwritten by the LL(1) one-token
+		 * lookahead.
+		 */
+		(ZIs) = xstrdup(lex_state->a);
+		if ((ZIs) == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+	
+#line 1489 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: pattern-buffer */
+			/* BEGINNING OF ACTION: make-ci-literal-term */
+			{
+#line 555 "src/parser.act"
+
+		char *p;
+
+		/* normalise case-insensitive strings for aesthetic reasons only */
+		for (p = (ZIs); *p != '\0'; p++) {
+			*p = tolower((unsigned char) *p);
+		}
+
+		(ZIt) = ast_make_literal_term((ZIs), 1);
+	
+#line 1505 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: make-ci-literal-term */
+		}
+		break;
+	case (TOK_CS__LITERAL):
+		{
+			map_string ZIs;
+
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: pattern-buffer */
+			{
+#line 477 "src/parser.act"
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		/*
+		 * Note we strdup() here because the grammar permits adjacent patterns,
+		 * and so the pattern buffer will be overwritten by the LL(1) one-token
+		 * lookahead.
+		 */
+		(ZIs) = xstrdup(lex_state->a);
+		if ((ZIs) == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+	
+#line 1535 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: pattern-buffer */
+			/* BEGINNING OF ACTION: make-cs-literal-term */
+			{
+#line 563 "src/parser.act"
+
+		(ZIt) = ast_make_literal_term((ZIs), 0);
+	
+#line 1544 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: make-cs-literal-term */
+		}
+		break;
+	case (TOK_PROSE):
+		{
+			map_string ZIs;
+
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: pattern-buffer */
+			{
+#line 477 "src/parser.act"
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		/*
+		 * Note we strdup() here because the grammar permits adjacent patterns,
+		 * and so the pattern buffer will be overwritten by the LL(1) one-token
+		 * lookahead.
+		 */
+		(ZIs) = xstrdup(lex_state->a);
+		if ((ZIs) == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+	
+#line 1574 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: pattern-buffer */
+			/* BEGINNING OF ACTION: make-prose-term */
+			{
+#line 573 "src/parser.act"
+
+		const char *s;
+
+		s = xstrdup(trim((ZIs)));
+
+		(ZIt) = ast_make_prose_term(s);
+
+		free((ZIs));
+	
+#line 1589 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: make-prose-term */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOt = ZIt;
+}
+
 /* BEGINNING OF TRAILER */
 
-#line 778 "src/parser.act"
+#line 807 "src/parser.act"
 
 
 	static int
@@ -1672,7 +1637,9 @@ ZL0:;
 		/* for dialects which don't use these */
 		(void) string;
 		(void) range;
+		(void) ltrim;
 		(void) rtrim;
+		(void) trim;
 
 		assert(f != NULL);
 
@@ -1767,6 +1734,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1771 "src/abnf/parser.c"
+#line 1738 "src/abnf/parser.c"
 
 /* END OF FILE */

--- a/src/abnf/parser.h
+++ b/src/abnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 270 "src/parser.act"
+#line 287 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_abnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 780 "src/parser.act"
+#line 809 "src/parser.act"
 
 
 #line 31 "src/abnf/parser.h"

--- a/src/abnf/parser.sid
+++ b/src/abnf/parser.sid
@@ -36,9 +36,10 @@
 	!STARTSTAR; !ENDSTAR;
 
 	!EMPTY;
-	NAME;
+	!NAME;
 	CI_LITERAL;
 	CS_LITERAL;
+	!PROSE;
 
 	!ESC:  () -> (:char);
 	CHAR:  () -> (:char);
@@ -72,6 +73,7 @@
 	<make-ci-literal-term>: (:string)      -> (:ast_term);
 	<make-cs-literal-term>: (:string)      -> (:ast_term);
 	!<make-token-term>:     (:string)      -> (:ast_term);
+	!<make-prose-term>:     (:string)      -> (:ast_term);
 	<make-group-term>:      (:ast_alt)     -> (:ast_term);
 	<make-range-term>:      (:char, :char) -> (:ast_term);
 
@@ -134,10 +136,9 @@
 		t = <make-cs-literal-term>(s);
 	||
 		body;
-		NAME;
-/* TODO: case insensitive */
+		PROSE;
 		s = <pattern-buffer>;
-		t = <make-rule-term>(s);
+		t = <make-prose-term>(s);
 	||
 		s = IDENT;
 /* TODO: case insensitive */
@@ -223,15 +224,8 @@
 	};
 
 	rule: () -> (r :ast_rule) = {
-		{
-			body;
-			NAME;
-			s = <pattern-buffer>;
+		s = IDENT;
 /* TODO: case insensitive! */
-		||
-			s = IDENT;
-/* TODO: case insensitive! */
-		};
 /* TODO: maybe need to flag case insensitivity in the AST for rule names,
 but expand out alts for literals */
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -124,6 +124,24 @@ ast_make_token_term(const char *token)
 }
 
 struct ast_term *
+ast_make_prose_term(const char *prose)
+{
+	struct ast_term *new;
+
+	assert(prose != NULL);
+
+	new = xmalloc(sizeof *new);
+	new->type    = TYPE_PROSE;
+	new->next    = NULL;
+	new->u.prose = prose;
+
+	new->min = 1;
+	new->max = 1;
+
+	return new;
+}
+
+struct ast_term *
 ast_make_group_term(struct ast_alt *group)
 {
 	struct ast_term *new;

--- a/src/ast.h
+++ b/src/ast.h
@@ -10,7 +10,8 @@
 struct ast_alt;
 
 enum ast_features {
-    FEATURE_AST_CI_LITERAL = 1 << 0
+    FEATURE_AST_CI_LITERAL = 1 << 0,
+    FEATURE_AST_PROSE      = 1 << 1
 };
 
 /*
@@ -28,6 +29,7 @@ struct ast_term {
 		TYPE_CS_LITERAL,
 		TYPE_CI_LITERAL,
 		TYPE_TOKEN,
+		TYPE_PROSE,
 		TYPE_GROUP
 	} type;
 
@@ -35,6 +37,7 @@ struct ast_term {
 		struct ast_rule *rule;
 		const char *literal;
 		const char *token;
+		const char *prose;
 		struct ast_alt *group;
 	} u;
 
@@ -84,6 +87,9 @@ ast_make_literal_term(const char *literal, int ci);
 
 struct ast_term *
 ast_make_token_term(const char *token);
+
+struct ast_term *
+ast_make_prose_term(const char *prose);
 
 struct ast_term *
 ast_make_group_term(struct ast_alt *group);

--- a/src/blab/output.c
+++ b/src/blab/output.c
@@ -14,6 +14,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>
@@ -107,6 +108,7 @@ atomic(const struct ast_term *term)
 	case TYPE_CI_LITERAL:
 	case TYPE_CS_LITERAL:
 	case TYPE_TOKEN:
+	case TYPE_PROSE:
 		return 1;
 
 	case TYPE_GROUP:
@@ -182,6 +184,10 @@ output_term(const struct ast_term *term)
 	case TYPE_TOKEN:
 		printf(" %s", term->u.token);
 		break;
+
+	case TYPE_PROSE:
+		fprintf(stderr, "unimplemented\n");
+		exit(EXIT_FAILURE);
 
 	case TYPE_GROUP:
 		output_group(term->u.group);

--- a/src/bnf/lexer.c
+++ b/src/bnf/lexer.c
@@ -441,21 +441,21 @@ z3(struct lx_bnf_lx *lx)
 
 		case S2: /* e.g. "\n" */
 			switch ((unsigned char) c) {
-			case '\n': state = S11; break;
+			case '\n': state = S10; break;
 			default:  lx_bnf_ungetc(lx, c); return lx->z(lx);
 			}
 			break;
 
 		case S3: /* e.g. "\"" */
 			switch ((unsigned char) c) {
-			case '"': state = S10; break;
+			case '"': state = S11; break;
 			default:  lx_bnf_ungetc(lx, c); return lx->z = z0, lx->z(lx);
 			}
 			break;
 
 		case S4: /* e.g. "'" */
 			switch ((unsigned char) c) {
-			case '\'': state = S10; break;
+			case '\'': state = S11; break;
 			default:  lx_bnf_ungetc(lx, c); return lx->z = z1, lx->z(lx);
 			}
 			break;
@@ -483,11 +483,11 @@ z3(struct lx_bnf_lx *lx)
 		case S9: /* e.g. "::=" */
 			lx_bnf_ungetc(lx, c); return TOK_EQUALS;
 
-		case S10: /* e.g. "''" */
-			lx_bnf_ungetc(lx, c); return TOK_EMPTY;
-
-		case S11: /* e.g. "\n\n" */
+		case S10: /* e.g. "\n\n" */
 			lx_bnf_ungetc(lx, c); return TOK_SEP;
+
+		case S11: /* e.g. "''" */
+			lx_bnf_ungetc(lx, c); return TOK_EMPTY;
 
 		default:
 			; /* unreached */
@@ -520,8 +520,8 @@ z3(struct lx_bnf_lx *lx)
 	case S6: return TOK_EOF;
 	case S7: return TOK_ALT;
 	case S9: return TOK_EQUALS;
-	case S10: return TOK_EMPTY;
-	case S11: return TOK_SEP;
+	case S10: return TOK_SEP;
+	case S11: return TOK_EMPTY;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }

--- a/src/bnf/output.c
+++ b/src/bnf/output.c
@@ -53,6 +53,10 @@ output_term(const struct ast_term *term)
 	case TYPE_TOKEN:
 		printf(" <%s>", term->u.token);
 		break;
+
+	case TYPE_PROSE:
+		fprintf(stderr, "unimplemented\n");
+		exit(EXIT_FAILURE);
 	}
 }
 

--- a/src/bnf/parser.c
+++ b/src/bnf/parser.c
@@ -201,6 +201,16 @@
 		return 0;
 	}
 
+	static const char *
+	ltrim(const char *s)
+	{
+		while (isspace((unsigned char) *s)) {
+			s++;
+		}
+
+		return s;
+	}
+
 	static void
 	rtrim(char *s)
 	{
@@ -211,6 +221,13 @@
 		while (p >= s && isspace((unsigned char) *p)) {
 			*p-- = '\0';
 		}
+	}
+
+	static const char *
+	trim(char *s)
+	{
+		rtrim(s);
+		return ltrim(s);
 	}
 
 	static void
@@ -242,7 +259,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 246 "src/bnf/parser.c"
+#line 263 "src/bnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -259,10 +276,10 @@ static void prod_body(lex_state, act_state);
 extern void prod_bnf(lex_state, act_state, map_rule *);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
-static void prod_87(lex_state, act_state, map_rule *);
-static void prod_88(lex_state, act_state, map_term *, map_alt *);
-static void prod_89(lex_state, act_state, map_term *);
-static void prod_90(lex_state, act_state, map_term *);
+static void prod_89(lex_state, act_state, map_rule *);
+static void prod_90(lex_state, act_state, map_term *, map_alt *);
+static void prod_91(lex_state, act_state, map_term *);
+static void prod_92(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -302,7 +319,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_89 (lex_state, act_state, &ZIl);
+		prod_91 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -326,7 +343,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_87 (lex_state, act_state, &ZIl);
+		prod_89 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -352,7 +369,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_88 (lex_state, act_state, &ZIt, &ZIl);
+		prod_90 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -375,20 +392,20 @@ ZL2_body:;
 		{
 			map_char ZIc;
 
-			/* BEGINNING OF INLINE: 66 */
+			/* BEGINNING OF INLINE: 68 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 289 "src/parser.act"
+#line 306 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 392 "src/bnf/parser.c"
+#line 409 "src/bnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -398,15 +415,15 @@ ZL2_body:;
 					ADVANCE_LEXER;
 				}
 			}
-			/* END OF INLINE: 66 */
+			/* END OF INLINE: 68 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 448 "src/parser.act"
+#line 465 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 410 "src/bnf/parser.c"
+#line 427 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -445,21 +462,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 587 "src/parser.act"
+#line 614 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 453 "src/bnf/parser.c"
+#line 470 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 634 "src/parser.act"
+#line 661 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 463 "src/bnf/parser.c"
+#line 480 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -478,11 +495,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 513 "src/parser.act"
+#line 530 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term();
 	
-#line 486 "src/bnf/parser.c"
+#line 503 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -490,7 +507,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 	case (TOK_NAME): case (TOK_CS__LITERAL): case (TOK_CHAR):
 		{
 			prod_body (lex_state, act_state);
-			prod_90 (lex_state, act_state, &ZIt);
+			prod_92 (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -535,7 +552,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: pattern-buffer */
 		{
-#line 460 "src/parser.act"
+#line 477 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = '\0';
@@ -553,10 +570,10 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 
 		lex_state->p = lex_state->a;
 	
-#line 557 "src/bnf/parser.c"
+#line 574 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: pattern-buffer */
-		/* BEGINNING OF INLINE: 79 */
+		/* BEGINNING OF INLINE: 81 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -572,17 +589,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 646 "src/parser.act"
+#line 673 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 580 "src/bnf/parser.c"
+#line 597 "src/bnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 79 */
+		/* END OF INLINE: 81 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -590,14 +607,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 583 "src/parser.act"
+#line 610 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 598 "src/bnf/parser.c"
+#line 615 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 80 */
+		/* BEGINNING OF INLINE: 82 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EOF):
@@ -618,17 +635,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 642 "src/parser.act"
+#line 669 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 626 "src/bnf/parser.c"
+#line 643 "src/bnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 80 */
+		/* END OF INLINE: 82 */
 	}
 	goto ZL0;
 ZL1:;
@@ -639,7 +656,7 @@ ZL0:;
 }
 
 static void
-prod_87(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_89(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_NAME): case (TOK_CHAR):
@@ -653,7 +670,7 @@ prod_87(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 602 "src/parser.act"
+#line 629 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -665,7 +682,7 @@ prod_87(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 669 "src/bnf/parser.c"
+#line 686 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -682,7 +699,7 @@ ZL1:;
 }
 
 static void
-prod_88(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_90(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -691,7 +708,7 @@ prod_88(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 75 */
+			/* BEGINNING OF INLINE: 77 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -707,17 +724,17 @@ prod_88(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 638 "src/parser.act"
+#line 665 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 715 "src/bnf/parser.c"
+#line 732 "src/bnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 75 */
+			/* END OF INLINE: 77 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -725,21 +742,21 @@ prod_88(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 733 "src/bnf/parser.c"
+#line 750 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 597 "src/parser.act"
+#line 624 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 743 "src/bnf/parser.c"
+#line 760 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -748,11 +765,11 @@ prod_88(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 756 "src/bnf/parser.c"
+#line 773 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -769,7 +786,7 @@ ZL0:;
 }
 
 static void
-prod_89(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_91(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_EMPTY): case (TOK_NAME): case (TOK_CS__LITERAL): case (TOK_CHAR):
@@ -783,12 +800,12 @@ prod_89(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 592 "src/parser.act"
+#line 619 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 792 "src/bnf/parser.c"
+#line 809 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -805,7 +822,7 @@ ZL1:;
 }
 
 static void
-prod_90(lex_state lex_state, act_state act_state, map_term *ZOt)
+prod_92(lex_state lex_state, act_state act_state, map_term *ZOt)
 {
 	map_term ZIt;
 
@@ -817,7 +834,7 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: pattern-buffer */
 			{
-#line 460 "src/parser.act"
+#line 477 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = '\0';
@@ -835,16 +852,16 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		lex_state->p = lex_state->a;
 	
-#line 839 "src/bnf/parser.c"
+#line 856 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: pattern-buffer */
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 546 "src/parser.act"
+#line 563 "src/parser.act"
 
 		(ZIt) = ast_make_literal_term((ZIs), 0);
 	
-#line 848 "src/bnf/parser.c"
+#line 865 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -856,7 +873,7 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: pattern-buffer */
 			{
-#line 460 "src/parser.act"
+#line 477 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = '\0';
@@ -874,12 +891,12 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		lex_state->p = lex_state->a;
 	
-#line 878 "src/bnf/parser.c"
+#line 895 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: pattern-buffer */
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 525 "src/parser.act"
+#line 542 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -897,7 +914,7 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 901 "src/bnf/parser.c"
+#line 918 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -917,7 +934,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 778 "src/parser.act"
+#line 807 "src/parser.act"
 
 
 	static int
@@ -949,7 +966,9 @@ ZL0:;
 		/* for dialects which don't use these */
 		(void) string;
 		(void) range;
+		(void) ltrim;
 		(void) rtrim;
+		(void) trim;
 
 		assert(f != NULL);
 
@@ -1044,6 +1063,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1048 "src/bnf/parser.c"
+#line 1067 "src/bnf/parser.c"
 
 /* END OF FILE */

--- a/src/bnf/parser.h
+++ b/src/bnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 270 "src/parser.act"
+#line 287 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_bnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 780 "src/parser.act"
+#line 809 "src/parser.act"
 
 
 #line 31 "src/bnf/parser.h"

--- a/src/bnf/parser.sid
+++ b/src/bnf/parser.sid
@@ -38,6 +38,7 @@
 	NAME;
 	!CI_LITERAL;
 	CS_LITERAL;
+	!PROSE;
 
 	!ESC:   () -> (:char);
 	CHAR:   () -> (:char);
@@ -71,6 +72,7 @@
 	!<make-ci-literal-term>: (:string)      -> (:ast_term);
 	<make-cs-literal-term>:  (:string)      -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
+	!<make-prose-term>:      (:string)      -> (:ast_term);
 	!<make-group-term>:      (:ast_alt)     -> (:ast_term);
 	!<make-range-term>:      (:char, :char) -> (:ast_term);
 

--- a/src/bs-ebnf/lexer.lx
+++ b/src/bs-ebnf/lexer.lx
@@ -4,10 +4,9 @@
 # See LICENCE for the full copyright terms.
 #
 
-# 7.6: Gap-separator
 /[ \t\r\n\v\f]+/;
 
-# Table 4: Invalid sequences of characters
+# Invalid sequences of characters
 # TODO: update for strings instead
 # TODO: permit -> $error for lx
 # '(*)' -> $error;
@@ -16,32 +15,21 @@
 
 '(*' .. '*)';
 
-"'" .. "'" -> $cs_literal {
-	/[^']/ -> $char;
-}
-
 '"' .. '"' -> $cs_literal {
 	/[^"]/ -> $char;
 }
 
-'?' .. '?' -> $prose {
-	/[^?]/ -> $char;
-}
-
-# Table 1: Representation of terminal-charaters
 '|' -> $alt;
 ';' -> $sep;
 '[' -> $startopt;  ']' -> $endopt;
-'{' -> $startstar; '}' -> $endstar; # zero or more times
+'{' -> $startstar; '}' -> $endstar;
 
-# Table 2: Alternative representation of terminal-characters
 '/' -> $alt;
 '!' -> $alt;
 '.' -> $sep;
 '(:' -> $startstar; ':)' -> $endstar; # TODO: rename to -rep
 '(/' -> $startopt;  '/)' -> $endopt;
 
-# tokens shared by both representations
 ',' -> $cat;
 '=' -> $equals;
 '(' -> $startgroup; ')' -> $endgroup;
@@ -51,15 +39,9 @@
 
 # spaces are permitted within EBNF names
 # XXX: I am unsure that this is correct. EBNF is far too complicated.
-# XXX: The ISO EBNF grammar seems to be ambigious with terminal character
-# containing hyphen, and I don't see how to distinguish that from an "except"
-# operator hyphen. So I'm taking the intuitively reasonable approach of not
-# permitting hyphens at the start and end of gap free symbols. This is my
-# own definition for $ident, rather than repeating the grammar from the spec.
 # TODO: when lx permits, we could remove rtrim() and write this using group
 #       capture to consume whitespace here, but disregard it.
-word = /[a-z][a-z0-9_]*(-[a-z0-9_]+)*/i;
-word (/[\t\r\n\v\f ]*/ word)* /[\t\r\n\v\f ]*/ -> $ident;
+/[a-z]([-a-z0-9_\t\r\n\v\f ]*)?/i -> $ident;
 
 /[0-9]+/ -> $count;
 

--- a/src/bs-ebnf/parser.sid
+++ b/src/bs-ebnf/parser.sid
@@ -6,12 +6,8 @@
 
 /*
  * Extended Backus-Naur Form Parser
- * As defined by ISO/IEC 14977:1996(E)
- *
- * TODO: postfix * (esp for groups, versus individual terms)
- * TODO: - subtraction thingies
- * TODO: names with spaces (<concaternate-name>(list-of-names))
- * TODO: multiplicative 3 * term stuff
+ * As defined by BS 6154
+equivalent to Standard ISO/IEC 14977
  */
 
 %types%
@@ -34,7 +30,7 @@
 	ALT;
 	SEP;
 	!REP;
-	EXCEPT;
+	!EXCEPT;
 
 	STAR;
 	CAT;
@@ -48,7 +44,7 @@
 	!NAME;
 	!CI_LITERAL;
 	CS_LITERAL;
-	PROSE;
+	!PROSE;
 
 	!ESC:  () -> (:char);
 	CHAR:  () -> (:char);
@@ -82,7 +78,7 @@
 	!<make-ci-literal-term>: (:string)      -> (:ast_term);
 	<make-cs-literal-term>:  (:string)      -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
-	<make-prose-term>:       (:string)      -> (:ast_term);
+	!<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:       (:ast_alt)     -> (:ast_term);
 	!<make-range-term>:      (:char, :char) -> (:ast_term);
 
@@ -102,7 +98,7 @@
 	<err-expected-alt>;
 	<err-expected-sep>;
 	<err-expected-equals>;
-	<err-unimplemented-except>;
+	!<err-unimplemented-except>;
 
 	list-of-terms: () -> (:ast_term);
 	list-of-alts:  () -> (:ast_alt);
@@ -125,11 +121,6 @@
 		CS_LITERAL;
 		s = <pattern-buffer>;
 		t = <make-cs-literal-term>(s);
-	||
-		body;
-		PROSE;
-		s = <pattern-buffer>;
-		t = <make-prose-term>(s);
 	||
 		s = IDENT;
 		t = <make-rule-term>(s);
@@ -182,20 +173,11 @@
 		<add-term-to-list>(t, l);
 	};
 
-	list-of-excepts: () -> (l :ast_term) = {
-		l = list-of-terms;
-	||
-		l = list-of-terms;
-		EXCEPT;
-		t = list-of-terms;
-		<err-unimplemented-except>;
-	};
-
 	list-of-alts: () -> (l :ast_alt) = {
-		t = list-of-excepts;
+		t = list-of-terms;
 		l = <make-alt>(t);
 	||
-		t = list-of-excepts;
+		t = list-of-terms;
 
 		{
 			ALT;

--- a/src/dot/output.c
+++ b/src/dot/output.c
@@ -127,6 +127,12 @@ output_term(const struct ast_rule *grammar,
 		escputs(term->u.token, stdout);
 		break;
 
+	case TYPE_PROSE:
+		fputs("?", stdout);
+		escputs(term->u.prose, stdout);
+		fputs("?", stdout);
+		break;
+
 	case TYPE_GROUP:
 		printf("()");
 		break;
@@ -148,6 +154,7 @@ output_term(const struct ast_rule *grammar,
 	case TYPE_CI_LITERAL:
 	case TYPE_CS_LITERAL:
 	case TYPE_TOKEN:
+	case TYPE_PROSE:
 		printf("\t\"t%p\" [ style = filled ];\n",
 			(void *) term);
 		break;

--- a/src/iso-ebnf/io.h
+++ b/src/iso-ebnf/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define iso_ebnf_ast_unsupported FEATURE_AST_CI_LITERAL
+#define iso_ebnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_PROSE)
 
 struct ast_rule *
 iso_ebnf_input(int (*f)(void *opaque), void *opaque);

--- a/src/iso-ebnf/lexer.h
+++ b/src/iso-ebnf/lexer.h
@@ -18,6 +18,7 @@ enum lx_iso_ebnf_token {
 	TOK_STARTOPT,
 	TOK_SEP,
 	TOK_ALT,
+	TOK_PROSE,
 	TOK_CHAR,
 	TOK_CS_LITERAL,
 	TOK_EOF,

--- a/src/iso-ebnf/output.c
+++ b/src/iso-ebnf/output.c
@@ -118,6 +118,11 @@ output_term(const struct ast_term *term)
 		printf(" %s", term->u.token);
 		break;
 
+	case TYPE_PROSE:
+		/* TODO: trim whitespace */
+		printf(" ? %s ?", term->u.prose);
+		break;
+
 	case TYPE_GROUP:
 		output_group(term->u.group);
 		break;

--- a/src/iso-ebnf/output.c
+++ b/src/iso-ebnf/output.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 
 #include "../ast.h"
+#include "../rrd/node.h"
 
 #include "io.h"
 
@@ -119,7 +120,11 @@ output_term(const struct ast_term *term)
 		break;
 
 	case TYPE_PROSE:
-		/* TODO: trim whitespace */
+		if (unquoted_prose(term->u.prose)) {
+			printf(" %s", term->u.prose);
+			break;
+		}
+
 		printf(" ? %s ?", term->u.prose);
 		break;
 

--- a/src/iso-ebnf/parser.c
+++ b/src/iso-ebnf/parser.c
@@ -201,6 +201,16 @@
 		return 0;
 	}
 
+	static const char *
+	ltrim(const char *s)
+	{
+		while (isspace((unsigned char) *s)) {
+			s++;
+		}
+
+		return s;
+	}
+
 	static void
 	rtrim(char *s)
 	{
@@ -211,6 +221,13 @@
 		while (p >= s && isspace((unsigned char) *p)) {
 			*p-- = '\0';
 		}
+	}
+
+	static const char *
+	trim(char *s)
+	{
+		rtrim(s);
+		return ltrim(s);
 	}
 
 	static void
@@ -242,7 +259,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 246 "src/iso-ebnf/parser.c"
+#line 263 "src/iso-ebnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -260,10 +277,11 @@ static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
 static void prod_repeatable_Hfactor(lex_state, act_state, map_term *);
-static void prod_92(lex_state, act_state, map_rule *);
-static void prod_93(lex_state, act_state, map_term *, map_alt *);
-static void prod_94(lex_state, act_state);
-static void prod_95(lex_state, act_state, map_term *);
+static void prod_94(lex_state, act_state, map_rule *);
+static void prod_95(lex_state, act_state, map_term *, map_alt *);
+static void prod_96(lex_state, act_state);
+static void prod_97(lex_state, act_state, map_term *);
+static void prod_98(lex_state, act_state, map_term *);
 static void prod_list_Hof_Hexcepts(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -295,11 +313,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 303 "src/iso-ebnf/parser.c"
+#line 321 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -324,33 +342,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 332 "src/iso-ebnf/parser.c"
+#line 350 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 481 "src/parser.act"
+#line 498 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 342 "src/iso-ebnf/parser.c"
+#line 360 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 354 "src/iso-ebnf/parser.c"
+#line 372 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -375,33 +393,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 383 "src/iso-ebnf/parser.c"
+#line 401 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 476 "src/parser.act"
+#line 493 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
 	
-#line 393 "src/iso-ebnf/parser.c"
+#line 411 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 405 "src/iso-ebnf/parser.c"
+#line 423 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -452,21 +470,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 587 "src/parser.act"
+#line 614 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 460 "src/iso-ebnf/parser.c"
+#line 478 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 634 "src/parser.act"
+#line 661 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 470 "src/iso-ebnf/parser.c"
+#line 488 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -484,7 +502,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_repeatable_Hfactor (lex_state, act_state, &ZIl);
-		prod_95 (lex_state, act_state, &ZIl);
+		prod_97 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -508,7 +526,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_92 (lex_state, act_state, &ZIl);
+		prod_94 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -534,7 +552,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hexcepts (lex_state, act_state, &ZIt);
-		prod_93 (lex_state, act_state, &ZIt, &ZIl);
+		prod_95 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -557,20 +575,20 @@ ZL2_body:;
 		{
 			map_char ZIc;
 
-			/* BEGINNING OF INLINE: 71 */
+			/* BEGINNING OF INLINE: 73 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 289 "src/parser.act"
+#line 306 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 574 "src/iso-ebnf/parser.c"
+#line 592 "src/iso-ebnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -580,15 +598,15 @@ ZL2_body:;
 					ADVANCE_LEXER;
 				}
 			}
-			/* END OF INLINE: 71 */
+			/* END OF INLINE: 73 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 448 "src/parser.act"
+#line 465 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 592 "src/iso-ebnf/parser.c"
+#line 610 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -619,7 +637,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 302 "src/parser.act"
+#line 319 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -636,13 +654,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 640 "src/iso-ebnf/parser.c"
+#line 658 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 525 "src/parser.act"
+#line 542 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -660,69 +678,30 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 664 "src/iso-ebnf/parser.c"
+#line 682 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
 		break;
-	case (TOK_CS__LITERAL): case (TOK_CHAR):
+	case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR):
 		{
-			map_string ZIs;
-
 			prod_body (lex_state, act_state);
-			switch (CURRENT_TERMINAL) {
-			case (TOK_CS__LITERAL):
-				break;
-			case (ERROR_TERMINAL):
+			prod_98 (lex_state, act_state, &ZIt);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
-			default:
-				goto ZL1;
 			}
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
-			{
-#line 460 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 704 "src/iso-ebnf/parser.c"
-			}
-			/* END OF ACTION: pattern-buffer */
-			/* BEGINNING OF ACTION: make-cs-literal-term */
-			{
-#line 546 "src/parser.act"
-
-		(ZIt) = ast_make_literal_term((ZIs), 0);
-	
-#line 713 "src/iso-ebnf/parser.c"
-			}
-			/* END OF ACTION: make-cs-literal-term */
 		}
 		break;
 	default:
 		{
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 513 "src/parser.act"
+#line 530 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term();
 	
-#line 726 "src/iso-ebnf/parser.c"
+#line 705 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -754,7 +733,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 302 "src/parser.act"
+#line 319 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -771,7 +750,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 775 "src/iso-ebnf/parser.c"
+#line 754 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -779,7 +758,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 87 */
+		/* BEGINNING OF INLINE: 89 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -795,17 +774,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 646 "src/parser.act"
+#line 673 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 803 "src/iso-ebnf/parser.c"
+#line 782 "src/iso-ebnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 87 */
+		/* END OF INLINE: 89 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -813,14 +792,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 583 "src/parser.act"
+#line 610 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 821 "src/iso-ebnf/parser.c"
+#line 800 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 88 */
+		/* BEGINNING OF INLINE: 90 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -836,17 +815,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 642 "src/parser.act"
+#line 669 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 844 "src/iso-ebnf/parser.c"
+#line 823 "src/iso-ebnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 88 */
+		/* END OF INLINE: 90 */
 	}
 	goto ZL0;
 ZL1:;
@@ -868,12 +847,12 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 310 "src/parser.act"
+#line 327 "src/parser.act"
 
 		ZIn = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 877 "src/iso-ebnf/parser.c"
+#line 856 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -891,7 +870,7 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: mul-repeat */
 			{
-#line 493 "src/parser.act"
+#line 510 "src/parser.act"
 
 		assert((ZIn) > 0);
 
@@ -910,7 +889,7 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(ZIt)->min *= (ZIn);
 		(ZIt)->max *= (ZIn);
 	
-#line 914 "src/iso-ebnf/parser.c"
+#line 893 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: mul-repeat */
 		}
@@ -936,7 +915,7 @@ ZL0:;
 }
 
 static void
-prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_94(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_IDENT):
@@ -950,7 +929,7 @@ prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 602 "src/parser.act"
+#line 629 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -962,7 +941,7 @@ prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 966 "src/iso-ebnf/parser.c"
+#line 945 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -979,7 +958,7 @@ ZL1:;
 }
 
 static void
-prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_95(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -988,7 +967,7 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 84 */
+			/* BEGINNING OF INLINE: 86 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -1004,17 +983,17 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 638 "src/parser.act"
+#line 665 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 1012 "src/iso-ebnf/parser.c"
+#line 991 "src/iso-ebnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 84 */
+			/* END OF INLINE: 86 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1022,21 +1001,21 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1030 "src/iso-ebnf/parser.c"
+#line 1009 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 597 "src/parser.act"
+#line 624 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1040 "src/iso-ebnf/parser.c"
+#line 1019 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1045,11 +1024,11 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1053 "src/iso-ebnf/parser.c"
+#line 1032 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1066,7 +1045,7 @@ ZL0:;
 }
 
 static void
-prod_94(lex_state lex_state, act_state act_state)
+prod_96(lex_state lex_state, act_state act_state)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_EXCEPT):
@@ -1081,11 +1060,11 @@ prod_94(lex_state lex_state, act_state act_state)
 			}
 			/* BEGINNING OF ACTION: err-unimplemented-except */
 			{
-#line 650 "src/parser.act"
+#line 677 "src/parser.act"
 
 		err_unimplemented(lex_state, "\"except\" productions");
 	
-#line 1089 "src/iso-ebnf/parser.c"
+#line 1068 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: err-unimplemented-except */
 		}
@@ -1102,7 +1081,7 @@ ZL1:;
 }
 
 static void
-prod_95(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_97(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CAT):
@@ -1117,12 +1096,12 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 592 "src/parser.act"
+#line 619 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1126 "src/iso-ebnf/parser.c"
+#line 1105 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1139,6 +1118,109 @@ ZL1:;
 }
 
 static void
+prod_98(lex_state lex_state, act_state act_state, map_term *ZOt)
+{
+	map_term ZIt;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CS__LITERAL):
+		{
+			map_string ZIs;
+
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: pattern-buffer */
+			{
+#line 477 "src/parser.act"
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		/*
+		 * Note we strdup() here because the grammar permits adjacent patterns,
+		 * and so the pattern buffer will be overwritten by the LL(1) one-token
+		 * lookahead.
+		 */
+		(ZIs) = xstrdup(lex_state->a);
+		if ((ZIs) == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+	
+#line 1152 "src/iso-ebnf/parser.c"
+			}
+			/* END OF ACTION: pattern-buffer */
+			/* BEGINNING OF ACTION: make-cs-literal-term */
+			{
+#line 563 "src/parser.act"
+
+		(ZIt) = ast_make_literal_term((ZIs), 0);
+	
+#line 1161 "src/iso-ebnf/parser.c"
+			}
+			/* END OF ACTION: make-cs-literal-term */
+		}
+		break;
+	case (TOK_PROSE):
+		{
+			map_string ZIs;
+
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: pattern-buffer */
+			{
+#line 477 "src/parser.act"
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		/*
+		 * Note we strdup() here because the grammar permits adjacent patterns,
+		 * and so the pattern buffer will be overwritten by the LL(1) one-token
+		 * lookahead.
+		 */
+		(ZIs) = xstrdup(lex_state->a);
+		if ((ZIs) == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+	
+#line 1191 "src/iso-ebnf/parser.c"
+			}
+			/* END OF ACTION: pattern-buffer */
+			/* BEGINNING OF ACTION: make-prose-term */
+			{
+#line 573 "src/parser.act"
+
+		const char *s;
+
+		s = xstrdup(trim((ZIs)));
+
+		(ZIt) = ast_make_prose_term(s);
+
+		free((ZIs));
+	
+#line 1206 "src/iso-ebnf/parser.c"
+			}
+			/* END OF ACTION: make-prose-term */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOt = ZIt;
+}
+
+static void
 prod_list_Hof_Hexcepts(lex_state lex_state, act_state act_state, map_term *ZOl)
 {
 	map_term ZIl;
@@ -1148,7 +1230,7 @@ prod_list_Hof_Hexcepts(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIl);
-		prod_94 (lex_state, act_state);
+		prod_96 (lex_state, act_state);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1164,7 +1246,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 778 "src/parser.act"
+#line 807 "src/parser.act"
 
 
 	static int
@@ -1196,7 +1278,9 @@ ZL0:;
 		/* for dialects which don't use these */
 		(void) string;
 		(void) range;
+		(void) ltrim;
 		(void) rtrim;
+		(void) trim;
 
 		assert(f != NULL);
 
@@ -1291,6 +1375,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1295 "src/iso-ebnf/parser.c"
+#line 1379 "src/iso-ebnf/parser.c"
 
 /* END OF FILE */

--- a/src/iso-ebnf/parser.h
+++ b/src/iso-ebnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 270 "src/parser.act"
+#line 287 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_iso_Hebnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 780 "src/parser.act"
+#line 809 "src/parser.act"
 
 
 #line 31 "src/iso-ebnf/parser.h"

--- a/src/parser.act
+++ b/src/parser.act
@@ -219,6 +219,16 @@
 		return 0;
 	}
 
+	static const char *
+	ltrim(const char *s)
+	{
+		while (isspace((unsigned char) *s)) {
+			s++;
+		}
+
+		return s;
+	}
+
 	static void
 	rtrim(char *s)
 	{
@@ -229,6 +239,13 @@
 		while (p >= s && isspace((unsigned char) *p)) {
 			*p-- = '\0';
 		}
+	}
+
+	static const char *
+	trim(char *s)
+	{
+		rtrim(s);
+		return ltrim(s);
 	}
 
 	static void
@@ -551,7 +568,13 @@
 	@};
 
 	<make-prose-term>: (l :string) -> (t :ast_term) = @{
-		@t = ast_make_prose_term(@l);
+		const char *s;
+
+		s = xstrdup(trim(@l));
+
+		@t = ast_make_prose_term(s);
+
+		free(@l);
 	@};
 
 	<make-group-term>: (a :ast_alt) -> (t :ast_term) = @{
@@ -684,7 +707,9 @@
 		/* for dialects which don't use these */
 		(void) string;
 		(void) range;
+		(void) ltrim;
 		(void) rtrim;
+		(void) trim;
 
 		assert(f != NULL);
 

--- a/src/parser.act
+++ b/src/parser.act
@@ -550,6 +550,10 @@
 		@t = ast_make_token_term(@n);
 	@};
 
+	<make-prose-term>: (l :string) -> (t :ast_term) = @{
+		@t = ast_make_prose_term(@l);
+	@};
+
 	<make-group-term>: (a :ast_alt) -> (t :ast_term) = @{
 		@t = ast_make_group_term(@a);
 	@};

--- a/src/rbnf/lexer.c
+++ b/src/rbnf/lexer.c
@@ -240,8 +240,8 @@ z1(struct lx_rbnf_lx *lx)
 			case '\r':
 			case ' ': state = S1; break;
 			case '\n': state = S2; break;
-			case ')': state = S4; break;
 			case '(': state = S3; break;
+			case ')': state = S4; break;
 			case '.': state = S5; break;
 			case ':': state = S6; break;
 			case '<': state = S7; break;
@@ -278,14 +278,14 @@ z1(struct lx_rbnf_lx *lx)
 
 		case S5: /* e.g. "." */
 			switch ((unsigned char) c) {
-			case '.': state = S13; break;
+			case '.': state = S11; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
 		case S6: /* e.g. ":" */
 			switch ((unsigned char) c) {
-			case ':': state = S11; break;
+			case ':': state = S12; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -302,22 +302,22 @@ z1(struct lx_rbnf_lx *lx)
 		case S10: /* e.g. "|" */
 			lx_rbnf_ungetc(lx, c); return TOK_ALT;
 
-		case S11: /* e.g. "::" */
-			switch ((unsigned char) c) {
-			case '=': state = S12; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S12: /* e.g. "::=" */
-			lx_rbnf_ungetc(lx, c); return TOK_EQUALS;
-
-		case S13: /* e.g. ".." */
+		case S11: /* e.g. ".." */
 			switch ((unsigned char) c) {
 			case '.': state = S14; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
+
+		case S12: /* e.g. "::" */
+			switch ((unsigned char) c) {
+			case '=': state = S13; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S13: /* e.g. "::=" */
+			lx_rbnf_ungetc(lx, c); return TOK_EQUALS;
 
 		case S14: /* e.g. "..." */
 			lx_rbnf_ungetc(lx, c); return TOK_REP;
@@ -357,7 +357,7 @@ z1(struct lx_rbnf_lx *lx)
 	case S8: return TOK_STARTOPT;
 	case S9: return TOK_ENDOPT;
 	case S10: return TOK_ALT;
-	case S12: return TOK_EQUALS;
+	case S13: return TOK_EQUALS;
 	case S14: return TOK_REP;
 	case S15: return TOK_SEP;
 	default: errno = EINVAL; return TOK_ERROR;

--- a/src/rbnf/output.c
+++ b/src/rbnf/output.c
@@ -106,6 +106,10 @@ output_term(const struct ast_term *term)
 		printf(" <%s>", term->u.token);
 		break;
 
+	case TYPE_PROSE:
+		fprintf(stderr, "unimplemented\n");
+		exit(EXIT_FAILURE);
+
 	case TYPE_GROUP:
 		output_group(term->u.group);
 		break;

--- a/src/rbnf/parser.c
+++ b/src/rbnf/parser.c
@@ -201,6 +201,16 @@
 		return 0;
 	}
 
+	static const char *
+	ltrim(const char *s)
+	{
+		while (isspace((unsigned char) *s)) {
+			s++;
+		}
+
+		return s;
+	}
+
 	static void
 	rtrim(char *s)
 	{
@@ -211,6 +221,13 @@
 		while (p >= s && isspace((unsigned char) *p)) {
 			*p-- = '\0';
 		}
+	}
+
+	static const char *
+	trim(char *s)
+	{
+		rtrim(s);
+		return ltrim(s);
 	}
 
 	static void
@@ -242,7 +259,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 246 "src/rbnf/parser.c"
+#line 263 "src/rbnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -259,9 +276,9 @@ extern void prod_rbnf(lex_state, act_state, map_rule *);
 static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
-static void prod_88(lex_state, act_state, map_rule *);
-static void prod_89(lex_state, act_state, map_term *, map_alt *);
-static void prod_90(lex_state, act_state, map_term *);
+static void prod_90(lex_state, act_state, map_rule *);
+static void prod_91(lex_state, act_state, map_term *, map_alt *);
+static void prod_92(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -292,11 +309,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 300 "src/rbnf/parser.c"
+#line 317 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -309,7 +326,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			ADVANCE_LEXER;
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
-			/* BEGINNING OF INLINE: 75 */
+			/* BEGINNING OF INLINE: 77 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_REP):
@@ -317,12 +334,12 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: rep-zero-or-more */
 						{
-#line 476 "src/parser.act"
+#line 493 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
 	
-#line 326 "src/rbnf/parser.c"
+#line 343 "src/rbnf/parser.c"
 						}
 						/* END OF ACTION: rep-zero-or-more */
 					}
@@ -331,12 +348,12 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF ACTION: rep-zero-or-one */
 						{
-#line 481 "src/parser.act"
+#line 498 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 340 "src/rbnf/parser.c"
+#line 357 "src/rbnf/parser.c"
 						}
 						/* END OF ACTION: rep-zero-or-one */
 					}
@@ -346,7 +363,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 75 */
+			/* END OF INLINE: 77 */
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ENDOPT):
 				break;
@@ -356,23 +373,23 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 364 "src/rbnf/parser.c"
+#line 381 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 376 "src/rbnf/parser.c"
+#line 393 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -409,7 +426,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_90 (lex_state, act_state, &ZIl);
+		prod_92 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -433,7 +450,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_88 (lex_state, act_state, &ZIl);
+		prod_90 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -459,7 +476,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_89 (lex_state, act_state, &ZIt, &ZIl);
+		prod_91 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -493,21 +510,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 587 "src/parser.act"
+#line 614 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 501 "src/rbnf/parser.c"
+#line 518 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 634 "src/parser.act"
+#line 661 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 511 "src/rbnf/parser.c"
+#line 528 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -524,20 +541,20 @@ ZL2_body:;
 		{
 			map_char ZIc;
 
-			/* BEGINNING OF INLINE: 68 */
+			/* BEGINNING OF INLINE: 70 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 289 "src/parser.act"
+#line 306 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 541 "src/rbnf/parser.c"
+#line 558 "src/rbnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -547,15 +564,15 @@ ZL2_body:;
 					ADVANCE_LEXER;
 				}
 			}
-			/* END OF INLINE: 68 */
+			/* END OF INLINE: 70 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 448 "src/parser.act"
+#line 465 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 559 "src/rbnf/parser.c"
+#line 576 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -598,7 +615,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: pattern-buffer */
 		{
-#line 460 "src/parser.act"
+#line 477 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = '\0';
@@ -616,12 +633,12 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		lex_state->p = lex_state->a;
 	
-#line 620 "src/rbnf/parser.c"
+#line 637 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: pattern-buffer */
 		/* BEGINNING OF ACTION: make-rule-term */
 		{
-#line 525 "src/parser.act"
+#line 542 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -639,7 +656,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 643 "src/rbnf/parser.c"
+#line 660 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: make-rule-term */
 	}
@@ -676,7 +693,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: pattern-buffer */
 		{
-#line 460 "src/parser.act"
+#line 477 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = '\0';
@@ -694,10 +711,10 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 
 		lex_state->p = lex_state->a;
 	
-#line 698 "src/rbnf/parser.c"
+#line 715 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: pattern-buffer */
-		/* BEGINNING OF INLINE: 82 */
+		/* BEGINNING OF INLINE: 84 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -713,17 +730,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 646 "src/parser.act"
+#line 673 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 721 "src/rbnf/parser.c"
+#line 738 "src/rbnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 82 */
+		/* END OF INLINE: 84 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -731,14 +748,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 583 "src/parser.act"
+#line 610 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 739 "src/rbnf/parser.c"
+#line 756 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 83 */
+		/* BEGINNING OF INLINE: 85 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EOF):
@@ -759,17 +776,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 642 "src/parser.act"
+#line 669 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 767 "src/rbnf/parser.c"
+#line 784 "src/rbnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 83 */
+		/* END OF INLINE: 85 */
 	}
 	goto ZL0;
 ZL1:;
@@ -780,7 +797,7 @@ ZL0:;
 }
 
 static void
-prod_88(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_90(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_NAME): case (TOK_CHAR):
@@ -794,7 +811,7 @@ prod_88(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 602 "src/parser.act"
+#line 629 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -806,7 +823,7 @@ prod_88(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 810 "src/rbnf/parser.c"
+#line 827 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -823,7 +840,7 @@ ZL1:;
 }
 
 static void
-prod_89(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -832,7 +849,7 @@ prod_89(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 79 */
+			/* BEGINNING OF INLINE: 81 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -848,17 +865,17 @@ prod_89(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 638 "src/parser.act"
+#line 665 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 856 "src/rbnf/parser.c"
+#line 873 "src/rbnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 79 */
+			/* END OF INLINE: 81 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -866,21 +883,21 @@ prod_89(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 874 "src/rbnf/parser.c"
+#line 891 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 597 "src/parser.act"
+#line 624 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 884 "src/rbnf/parser.c"
+#line 901 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -889,11 +906,11 @@ prod_89(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 897 "src/rbnf/parser.c"
+#line 914 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -910,7 +927,7 @@ ZL0:;
 }
 
 static void
-prod_90(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_92(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_NAME): case (TOK_CHAR):
@@ -924,12 +941,12 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 592 "src/parser.act"
+#line 619 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 933 "src/rbnf/parser.c"
+#line 950 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -947,7 +964,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 778 "src/parser.act"
+#line 807 "src/parser.act"
 
 
 	static int
@@ -979,7 +996,9 @@ ZL1:;
 		/* for dialects which don't use these */
 		(void) string;
 		(void) range;
+		(void) ltrim;
 		(void) rtrim;
+		(void) trim;
 
 		assert(f != NULL);
 
@@ -1074,6 +1093,6 @@ ZL1:;
 		return g;
 	}
 
-#line 1078 "src/rbnf/parser.c"
+#line 1097 "src/rbnf/parser.c"
 
 /* END OF FILE */

--- a/src/rbnf/parser.h
+++ b/src/rbnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 270 "src/parser.act"
+#line 287 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_rbnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 780 "src/parser.act"
+#line 809 "src/parser.act"
 
 
 #line 31 "src/rbnf/parser.h"

--- a/src/rbnf/parser.sid
+++ b/src/rbnf/parser.sid
@@ -38,6 +38,7 @@
 	NAME;
 	!CI_LITERAL;
 	!CS_LITERAL;
+	!PROSE;
 
 	!ESC:   () -> (:char);
 	CHAR:   () -> (:char);
@@ -71,6 +72,7 @@
 	!<make-ci-literal-term>: (:string)      -> (:ast_term);
 	!<make-cs-literal-term>: (:string)      -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
+	!<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:       (:ast_alt)     -> (:ast_term);
 	!<make-range-term>:      (:char, :char) -> (:ast_term);
 

--- a/src/rewrite_ci.c
+++ b/src/rewrite_ci.c
@@ -93,6 +93,7 @@ walk_alt(struct ast_alt *alt)
 		case TYPE_EMPTY:
 		case TYPE_CS_LITERAL:
 		case TYPE_TOKEN:
+		case TYPE_PROSE:
 			break;
 
 		case TYPE_GROUP:

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -14,6 +14,12 @@
 
 #include "../xalloc.h"
 
+int
+unquoted_prose(const char *prose)
+{
+	return prose[0] == '(' && prose[strlen(prose) - 1] == ')';
+}
+
 void
 node_free(struct node *n)
 {

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -102,6 +102,22 @@ node_create_name(const char *name)
 }
 
 struct node *
+node_create_prose(const char *prose)
+{
+	struct node *new;
+
+	assert(prose != NULL);
+
+	new = xmalloc(sizeof *new);
+
+	new->type = NODE_PROSE;
+
+	new->u.prose = prose;
+
+	return new;
+}
+
+struct node *
 node_create_alt(struct list *alt)
 {
 	struct node *new;

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -16,6 +16,7 @@ struct node {
 		NODE_CI_LITERAL,
 		NODE_CS_LITERAL,
 		NODE_RULE,
+		NODE_PROSE,
 		NODE_ALT,
 		NODE_ALT_SKIPPABLE,
 		NODE_SEQ,
@@ -25,6 +26,7 @@ struct node {
 	union {
 		const char *literal; /* TODO: point to ast_literal instead */
 		const char *name;    /* TODO: point to ast_rule instead */
+		const char *prose;
 
 		struct list *alt;
 		struct list *seq;
@@ -49,6 +51,9 @@ node_create_cs_literal(const char *literal);
 
 struct node *
 node_create_name(const char *name);
+
+struct node *
+node_create_prose(const char *name);
 
 struct node *
 node_create_alt(struct list *alt);

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -40,6 +40,9 @@ struct node {
 	} u;
 };
 
+int
+unquoted_prose(const char *prose);
+
 void
 node_free(struct node *);
 

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -144,8 +144,8 @@ tnode_free(struct tnode *n)
 		free((void *) n->u.literal);
 		break;
 
-	case TNODE_LABEL:
-		free((void *) n->u.label);
+	case TNODE_PROSE:
+		free((void *) n->u.prose);
 		break;
 
 	case TNODE_VLIST:
@@ -447,6 +447,12 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 		new->w += dim->rule_padding;
 		break;
 
+	case NODE_PROSE:
+		new->type = TNODE_PROSE;
+		new->u.prose = node->u.prose;
+		dim->rule_string(new->u.prose, &new->w, &new->a, &new->d);
+		break;
+
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
 		new->type = TNODE_VLIST;
@@ -657,8 +663,8 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 
 					/* if there's nothing to show for the backwards node, put the label there */
 					label_tnode = new->u.vlist.a[1];
-					label_tnode->type = TNODE_LABEL;
-					label_tnode->u.label = label;
+					label_tnode->type = TNODE_PROSE;
+					label_tnode->u.prose = label;
 					dim->rule_string(label, &label_tnode->w, &label_tnode->a, &label_tnode->d);
 				} else {
 					/* TODO: store label somewhere for rendering to display somehow */

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -451,6 +451,9 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 		new->type = TNODE_PROSE;
 		new->u.prose = node->u.prose;
 		dim->rule_string(new->u.prose, &new->w, &new->a, &new->d);
+		if (!unquoted_prose(node->u.prose)) {
+			new->w += dim->prose_padding;
+		}
 		break;
 
 	case NODE_ALT:

--- a/src/rrd/tnode.h
+++ b/src/rrd/tnode.h
@@ -63,7 +63,7 @@ struct tnode {
 		TNODE_ELLIPSIS,
 		TNODE_CI_LITERAL,
 		TNODE_CS_LITERAL,
-		TNODE_LABEL,
+		TNODE_PROSE,
 		TNODE_RULE,
 		TNODE_VLIST,
 		TNODE_HLIST
@@ -79,7 +79,7 @@ struct tnode {
 	union {
 		const char *literal; /* TODO: point to ast_literal instead */
 		const char *name;    /* TODO: point to ast_rule instead */
-		const char *label;
+		const char *prose;
 
 		struct tnode_vlist vlist;
 		struct tnode_hlist hlist;

--- a/src/rrd/tnode.h
+++ b/src/rrd/tnode.h
@@ -91,6 +91,7 @@ struct dim {
 	void (*rule_string   )(const char *s, unsigned *w, unsigned *a, unsigned *d);
 	unsigned literal_padding;
 	unsigned rule_padding;
+	unsigned prose_padding;
 	unsigned ci_marker;
 };
 

--- a/src/rrd/transform.c
+++ b/src/rrd/transform.c
@@ -116,6 +116,10 @@ single_term(const struct ast_term *term, struct node **r)
 		*r = node_create_name(term->u.token);
 		return 1;
 
+	case TYPE_PROSE:
+		*r = node_create_prose(term->u.prose);
+		return 1;
+
 	case TYPE_GROUP:
 		return transform_alts(term->u.group, r);
 	}

--- a/src/rrdot/output.c
+++ b/src/rrdot/output.c
@@ -130,6 +130,12 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 		printf("\\>\"");
 		break;
 
+	case NODE_PROSE:
+		printf("label = \"?");
+		escputs(node->u.prose, stdout);
+		printf("?\"");
+		break;
+
 	case NODE_ALT:
 		printf("label = \"ALT\"");
 		break;

--- a/src/rrdump/output.c
+++ b/src/rrdump/output.c
@@ -65,6 +65,12 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 		break;
 
+	case NODE_PROSE:
+		print_indent(f, depth);
+		fprintf(f, "PROSE: ?%s?\n", n->u.prose);
+
+		break;
+
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);

--- a/src/rrll/output.c
+++ b/src/rrll/output.c
@@ -142,6 +142,13 @@ node_walk(FILE *f, const struct node *n)
 
 		break;
 
+	case NODE_PROSE:
+		fprintf(f, "`");
+		escputs(n->u.prose, f);
+		fprintf(f, "`");
+
+		break;
+
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
 		fprintf(f, "<");

--- a/src/rrparcon/output.c
+++ b/src/rrparcon/output.c
@@ -155,6 +155,10 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 		break;
 
+	case NODE_PROSE:
+		fprintf(stderr, "unimplemented\n");
+		exit(EXIT_FAILURE);
+
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);

--- a/src/rrta/output.c
+++ b/src/rrta/output.c
@@ -156,6 +156,10 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 		break;
 
+	case NODE_PROSE:
+		fprintf(stderr, "unimplemented\n");
+		exit(EXIT_FAILURE);
+
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -159,6 +159,7 @@ rrtdump_output(const struct ast_rule *grammar)
 		dim_mono_string,
 		0,
 		0,
+		0,
 		0
 	};
 

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -90,11 +90,11 @@ tnode_walk(FILE *f, const struct tnode *n, int depth)
 
 		break;
 
-	case TNODE_LABEL:
+	case TNODE_PROSE:
 		print_indent(f, depth);
-		fprintf(f, "LABEL");
+		fprintf(f, "PROSE");
 		print_coords(f, n);
-		fprintf(f, ": %s\n", n->u.label);
+		fprintf(f, ": %s\n", n->u.prose);
 
 		break;
 

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -220,8 +220,8 @@ node_walk_render(const struct tnode *n, struct render_context *ctx)
 		bprintf(ctx, " \"%s\" ", n->u.literal);
 		break;
 
-	case TNODE_LABEL:
-		bprintf(ctx, "%s", n->u.label);
+	case TNODE_PROSE:
+		bprintf(ctx, "%s", n->u.prose);
 		break;
 
 	case TNODE_RULE:

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -221,7 +221,12 @@ node_walk_render(const struct tnode *n, struct render_context *ctx)
 		break;
 
 	case TNODE_PROSE:
-		bprintf(ctx, "%s", n->u.prose);
+		if (unquoted_prose(n->u.prose)) {
+			bprintf(ctx, "%s", n->u.prose);
+			break;
+		}
+
+		bprintf(ctx, "? %s ?", n->u.prose);
 		break;
 
 	case TNODE_RULE:
@@ -302,6 +307,7 @@ rrtext_output(const struct ast_rule *grammar)
 		dim_mono_string,
 		4,
 		2,
+		4,
 		2
 	};
 

--- a/src/sid/output.c
+++ b/src/sid/output.c
@@ -64,6 +64,10 @@ output_basic(const struct ast_term *term)
 		printf("%s; ", term->u.token);
 		break;
 
+	case TYPE_PROSE:
+		fprintf(stderr, "unimplemented\n");
+		exit(EXIT_FAILURE);
+
 	case TYPE_GROUP:
 		fputs("{ ", stdout);
 		output_alt(term->u.group);
@@ -132,6 +136,7 @@ is_equal(const struct ast_term *a, const struct ast_term *b)
 	case TYPE_CI_LITERAL: return 0 == strcasecmp(a->u.literal, b->u.literal);
 	case TYPE_CS_LITERAL: return 0 == strcmp(a->u.literal,     b->u.literal);
 	case TYPE_TOKEN:      return 0 == strcmp(a->u.token,       b->u.token);
+	case TYPE_PROSE:      return 0 == strcmp(a->u.prose,       b->u.prose);
 	}
 }
 
@@ -157,6 +162,7 @@ output_terminals(const struct ast_rule *grammar)
 
 				case TYPE_RULE:
 				case TYPE_TOKEN:
+				case TYPE_PROSE:
 					continue;
 
 				case TYPE_CI_LITERAL:

--- a/src/svg/output.c
+++ b/src/svg/output.c
@@ -623,6 +623,7 @@ struct dim svg_dim = {
 	dim_prop_string,
 	0,
 	0,
+	0,
 	2
 };
 

--- a/src/svg/output.c
+++ b/src/svg/output.c
@@ -118,12 +118,12 @@ svg_textbox(struct render_context *ctx, const char *s, unsigned w, unsigned r,
 }
 
 static void
-svg_label(struct render_context *ctx, const char *s, unsigned w)
+svg_prose(struct render_context *ctx, const char *s, unsigned w)
 {
 	assert(ctx != NULL);
 	assert(s != NULL);
 
-	svg_text(ctx, w, s, "label");
+	svg_text(ctx, w, s, "prose");
 
 	ctx->x += w;
 }
@@ -444,8 +444,8 @@ node_walk_render(const struct tnode *n,
 		svg_textbox(ctx, n->u.literal, n->w * 10, 8, "literal");
 		break;
 
-	case TNODE_LABEL:
-		svg_label(ctx, n->u.label, n->w * 10);
+	case TNODE_PROSE:
+		svg_prose(ctx, n->u.prose, n->w * 10);
 		break;
 
 	case TNODE_RULE:

--- a/src/wsn/parser.c
+++ b/src/wsn/parser.c
@@ -201,6 +201,16 @@
 		return 0;
 	}
 
+	static const char *
+	ltrim(const char *s)
+	{
+		while (isspace((unsigned char) *s)) {
+			s++;
+		}
+
+		return s;
+	}
+
 	static void
 	rtrim(char *s)
 	{
@@ -211,6 +221,13 @@
 		while (p >= s && isspace((unsigned char) *p)) {
 			*p-- = '\0';
 		}
+	}
+
+	static const char *
+	trim(char *s)
+	{
+		rtrim(s);
+		return ltrim(s);
 	}
 
 	static void
@@ -242,7 +259,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 246 "src/wsn/parser.c"
+#line 263 "src/wsn/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -258,10 +275,10 @@ static void prod_list_Hof_Halts(lex_state, act_state, map_alt *);
 static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
-static void prod_90(lex_state, act_state, map_rule *);
 extern void prod_wsn(lex_state, act_state, map_rule *);
-static void prod_91(lex_state, act_state, map_term *, map_alt *);
-static void prod_92(lex_state, act_state, map_term *);
+static void prod_92(lex_state, act_state, map_rule *);
+static void prod_93(lex_state, act_state, map_term *, map_alt *);
+static void prod_94(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -292,11 +309,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 300 "src/wsn/parser.c"
+#line 317 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -321,33 +338,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 329 "src/wsn/parser.c"
+#line 346 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 481 "src/parser.act"
+#line 498 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 339 "src/wsn/parser.c"
+#line 356 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 351 "src/wsn/parser.c"
+#line 368 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -372,33 +389,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 554 "src/parser.act"
+#line 581 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 380 "src/wsn/parser.c"
+#line 397 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 476 "src/parser.act"
+#line 493 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
 	
-#line 390 "src/wsn/parser.c"
+#line 407 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 486 "src/parser.act"
+#line 503 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 402 "src/wsn/parser.c"
+#line 419 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -436,7 +453,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_92 (lex_state, act_state, &ZIl);
+		prod_94 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -460,7 +477,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_90 (lex_state, act_state, &ZIl);
+		prod_92 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -486,7 +503,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_91 (lex_state, act_state, &ZIt, &ZIl);
+		prod_93 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -509,20 +526,20 @@ ZL2_body:;
 		{
 			map_char ZIc;
 
-			/* BEGINNING OF INLINE: 71 */
+			/* BEGINNING OF INLINE: 73 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
 					{
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 289 "src/parser.act"
+#line 306 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 526 "src/wsn/parser.c"
+#line 543 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -532,13 +549,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: ESC */
 						{
-#line 283 "src/parser.act"
+#line 300 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 2);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 542 "src/wsn/parser.c"
+#line 559 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -548,15 +565,15 @@ ZL2_body:;
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 71 */
+			/* END OF INLINE: 73 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 448 "src/parser.act"
+#line 465 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 560 "src/wsn/parser.c"
+#line 577 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -586,11 +603,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 513 "src/parser.act"
+#line 530 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term();
 	
-#line 594 "src/wsn/parser.c"
+#line 611 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -601,7 +618,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 302 "src/parser.act"
+#line 319 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -618,13 +635,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 622 "src/wsn/parser.c"
+#line 639 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 525 "src/parser.act"
+#line 542 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -642,7 +659,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 646 "src/wsn/parser.c"
+#line 663 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -664,7 +681,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: pattern-buffer */
 			{
-#line 460 "src/parser.act"
+#line 477 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = '\0';
@@ -682,16 +699,16 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		lex_state->p = lex_state->a;
 	
-#line 686 "src/wsn/parser.c"
+#line 703 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: pattern-buffer */
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 546 "src/parser.act"
+#line 563 "src/parser.act"
 
 		(ZIt) = ast_make_literal_term((ZIs), 0);
 	
-#line 695 "src/wsn/parser.c"
+#line 712 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -725,7 +742,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 302 "src/parser.act"
+#line 319 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -742,7 +759,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 746 "src/wsn/parser.c"
+#line 763 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -750,7 +767,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 84 */
+		/* BEGINNING OF INLINE: 86 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -766,17 +783,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 646 "src/parser.act"
+#line 673 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 774 "src/wsn/parser.c"
+#line 791 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 84 */
+		/* END OF INLINE: 86 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -784,14 +801,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 583 "src/parser.act"
+#line 610 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 792 "src/wsn/parser.c"
+#line 809 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 85 */
+		/* BEGINNING OF INLINE: 87 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -807,17 +824,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 642 "src/parser.act"
+#line 669 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 815 "src/wsn/parser.c"
+#line 832 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 85 */
+		/* END OF INLINE: 87 */
 	}
 	goto ZL0;
 ZL1:;
@@ -825,49 +842,6 @@ ZL1:;
 	return;
 ZL0:;
 	*ZOr = ZIr;
-}
-
-static void
-prod_90(lex_state lex_state, act_state act_state, map_rule *ZIl)
-{
-	switch (CURRENT_TERMINAL) {
-	case (TOK_IDENT):
-		{
-			map_rule ZIr;
-
-			prod_list_Hof_Hrules (lex_state, act_state, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: add-rule-to-list */
-			{
-#line 602 "src/parser.act"
-
-		if (ast_find_rule((ZIr), (*ZIl)->name)) {
-			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
-			/* TODO: print location of this and previous definition */
-			/* TODO: handle as warning; add rule anyway, and bail out at end */
-			exit(EXIT_FAILURE);
-		}
-
-		assert((*ZIl)->next == NULL);
-		(*ZIl)->next = (ZIr);
-	
-#line 858 "src/wsn/parser.c"
-			}
-			/* END OF ACTION: add-rule-to-list */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		break;
-	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 void
@@ -896,21 +870,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 587 "src/parser.act"
+#line 614 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 904 "src/wsn/parser.c"
+#line 878 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 634 "src/parser.act"
+#line 661 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 914 "src/wsn/parser.c"
+#line 888 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -919,7 +893,50 @@ ZL0:;
 }
 
 static void
-prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
+{
+	switch (CURRENT_TERMINAL) {
+	case (TOK_IDENT):
+		{
+			map_rule ZIr;
+
+			prod_list_Hof_Hrules (lex_state, act_state, &ZIr);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			/* BEGINNING OF ACTION: add-rule-to-list */
+			{
+#line 629 "src/parser.act"
+
+		if (ast_find_rule((ZIr), (*ZIl)->name)) {
+			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
+			/* TODO: print location of this and previous definition */
+			/* TODO: handle as warning; add rule anyway, and bail out at end */
+			exit(EXIT_FAILURE);
+		}
+
+		assert((*ZIl)->next == NULL);
+		(*ZIl)->next = (ZIr);
+	
+#line 923 "src/wsn/parser.c"
+			}
+			/* END OF ACTION: add-rule-to-list */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		break;
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+}
+
+static void
+prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -928,7 +945,7 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 81 */
+			/* BEGINNING OF INLINE: 83 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -944,17 +961,17 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 638 "src/parser.act"
+#line 665 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 952 "src/wsn/parser.c"
+#line 969 "src/wsn/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 81 */
+			/* END OF INLINE: 83 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -962,21 +979,21 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 970 "src/wsn/parser.c"
+#line 987 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 597 "src/parser.act"
+#line 624 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 980 "src/wsn/parser.c"
+#line 997 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -985,11 +1002,11 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 579 "src/parser.act"
+#line 606 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 993 "src/wsn/parser.c"
+#line 1010 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1006,7 +1023,7 @@ ZL0:;
 }
 
 static void
-prod_92(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_94(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_STARTSTAR): case (TOK_EMPTY):
@@ -1021,12 +1038,12 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 592 "src/parser.act"
+#line 619 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1030 "src/wsn/parser.c"
+#line 1047 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1044,7 +1061,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 778 "src/parser.act"
+#line 807 "src/parser.act"
 
 
 	static int
@@ -1076,7 +1093,9 @@ ZL1:;
 		/* for dialects which don't use these */
 		(void) string;
 		(void) range;
+		(void) ltrim;
 		(void) rtrim;
+		(void) trim;
 
 		assert(f != NULL);
 
@@ -1171,6 +1190,6 @@ ZL1:;
 		return g;
 	}
 
-#line 1175 "src/wsn/parser.c"
+#line 1194 "src/wsn/parser.c"
 
 /* END OF FILE */

--- a/src/wsn/parser.h
+++ b/src/wsn/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 270 "src/parser.act"
+#line 287 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_wsn(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 780 "src/parser.act"
+#line 809 "src/parser.act"
 
 
 #line 31 "src/wsn/parser.h"

--- a/src/wsn/parser.sid
+++ b/src/wsn/parser.sid
@@ -42,6 +42,7 @@
 	!NAME;
 	!CI_LITERAL;
 	CS_LITERAL;
+	!PROSE;
 
 	ESC:    () -> (:char);
 	CHAR:   () -> (:char);
@@ -75,6 +76,7 @@
 	!<make-ci-literal-term>: (:string)      -> (:ast_term);
 	<make-cs-literal-term>:  (:string)      -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
+	!<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:       (:ast_alt)     -> (:ast_term);
 	!<make-range-term>:      (:char, :char) -> (:ast_term);
 


### PR DESCRIPTION
Commenting on #10, ABNF's prose values are _typically_ `< ... >`:
> Unlike original BNF, angle brackets ("<", ">") are not required. However, angle brackets may be used around a rule name whenever their presence facilitates in discerning the use of a rule name. This is typically restricted to rule name references in free-form prose, or to distinguish partial rules that combine into a string not separated by white space, such as shown in the discussion about repetition, below.

In this implementation I treat these always as prose values, and do not permit angle-bracketed rule names.

ISO EBNF's special values are the same idea, written `? ... ?`. I prefer the term "prose" for the internal naming.

Loop labels have been consolidated to the same node type. I'd thought this would simplify rendering, but it turns out to be complicated by special handling for omitting the `? ... ?` quotes for those.

Output looks like this:
```
; echo 'e = ? xyz ?;' | ./build/bin/kgt -l iso-ebnf -e rrtext
e:
    ||--? xyz ?--||

; echo 'e = < xyz >;' | ./build/bin/kgt -l abnf -e iso-ebnf
e = ? xyz ?
        ;
```
with no surrounding rectangle for SVG rendering.