### PR TITLE
Reintroduce loop iteration labels, now as a comment tnode type

### DIFF
--- a/src/iso-ebnf/output.c
+++ b/src/iso-ebnf/output.c
@@ -120,11 +120,6 @@ output_term(const struct ast_term *term)
 		break;
 
 	case TYPE_PROSE:
-		if (unquoted_prose(term->u.prose)) {
-			printf(" %s", term->u.prose);
-			break;
-		}
-
 		printf(" ? %s ?", term->u.prose);
 		break;
 

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -14,12 +14,6 @@
 
 #include "../xalloc.h"
 
-int
-unquoted_prose(const char *prose)
-{
-	return prose[0] == '(' && prose[strlen(prose) - 1] == ')';
-}
-
 void
 node_free(struct node *n)
 {

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -40,9 +40,6 @@ struct node {
 	} u;
 };
 
-int
-unquoted_prose(const char *prose);
-
 void
 node_free(struct node *);
 

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -742,29 +742,6 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 		}
 
 		{
-			char s[128]; /* XXX */
-			const char *label;
-
-			loop_label(node->u.loop.min, node->u.loop.max, s);
-			label = esc_literal(s);
-
-			if (strlen(label) != 0) {
-				if (new->u.vlist.a[1]->type == TNODE_SKIP || new->u.vlist.a[1]->type == (rtl ? TNODE_RTL_ARROW : TNODE_LTR_ARROW)) {
-					struct tnode *label_tnode;
-
-					/* if there's nothing to show for the backwards node, put the label there */
-					label_tnode = new->u.vlist.a[1];
-					label_tnode->type = TNODE_PROSE;
-					label_tnode->u.prose = label;
-					dim->rule_string(label, &label_tnode->w, &label_tnode->a, &label_tnode->d);
-				} else {
-					/* TODO: store label somewhere for rendering to display somehow */
-					assert(!"unimplemented");
-				}
-			}
-		}
-
-		{
 			unsigned w;
 			unsigned wf, wb;
 
@@ -816,6 +793,18 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 					new->a += new->u.vlist.a[0]->a + new->u.vlist.a[0]->d + 1;
 					new->d -= new->u.vlist.a[0]->a + new->u.vlist.a[0]->d + 1;
 				}
+			}
+		}
+
+		{
+			char s[128]; /* XXX */
+			const char *label;
+
+			loop_label(node->u.loop.min, node->u.loop.max, s);
+			label = esc_literal(s);
+
+			if (strlen(label) != 0) {
+				new = tnode_create_comment(new, label, dim);
 			}
 		}
 

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -539,9 +539,7 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 		new->type = TNODE_PROSE;
 		new->u.prose = node->u.prose;
 		dim->rule_string(new->u.prose, &new->w, &new->a, &new->d);
-		if (!unquoted_prose(node->u.prose)) {
-			new->w += dim->prose_padding;
-		}
+		new->w += dim->prose_padding;
 		break;
 
 	case NODE_ALT:

--- a/src/rrd/tnode.h
+++ b/src/rrd/tnode.h
@@ -64,6 +64,7 @@ struct tnode {
 		TNODE_ELLIPSIS,
 		TNODE_CI_LITERAL,
 		TNODE_CS_LITERAL,
+		TNODE_COMMENT,
 		TNODE_PROSE,
 		TNODE_RULE,
 		TNODE_VLIST,
@@ -80,6 +81,11 @@ struct tnode {
 		const char *name;    /* TODO: point to ast_rule instead */
 		const char *prose;
 
+		struct {
+			const char *s;
+			const struct tnode *tnode;
+		} comment;
+
 		struct tnode_vlist vlist;
 		struct tnode_hlist hlist;
 	} u;
@@ -91,6 +97,7 @@ struct dim {
 	unsigned literal_padding;
 	unsigned rule_padding;
 	unsigned prose_padding;
+	unsigned comment_height;
 	unsigned ci_marker;
 	unsigned ellipsis_depth;
 };

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -99,6 +99,18 @@ tnode_walk(FILE *f, const struct tnode *n, int depth)
 
 		break;
 
+	case TNODE_COMMENT:
+		print_indent(f, depth);
+		fprintf(f, "COMMENT");
+		print_coords(f, n);
+		fprintf(f, " \"%s\"", n->u.comment.s);
+		fprintf(f, ": (\n");
+		tnode_walk(f, n->u.comment.tnode, depth + 1);
+		print_indent(f, depth);
+		fprintf(f, ")\n");
+
+		break;
+
 	case TNODE_RULE:
 		print_indent(f, depth);
 		fprintf(f, "RULE");
@@ -158,6 +170,7 @@ rrtdump_output(const struct ast_rule *grammar)
 	struct dim dim = {
 		dim_mono_string,
 		dim_mono_string,
+		0,
 		0,
 		0,
 		0,

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -269,11 +269,6 @@ node_walk_render(const struct tnode *n, struct render_context *ctx)
 		break;
 
 	case TNODE_PROSE:
-		if (unquoted_prose(n->u.prose)) {
-			bprintf(ctx, "%s", n->u.prose);
-			break;
-		}
-
 		bprintf(ctx, "? %s ?", n->u.prose);
 		break;
 

--- a/src/svg/output.c
+++ b/src/svg/output.c
@@ -472,15 +472,26 @@ node_walk_render(const struct tnode *n,
 		svg_prose(ctx, n->u.prose, n->w * 10);
 		break;
 
-	case TNODE_COMMENT:
+	case TNODE_COMMENT: {
+		unsigned offset = 5;
+
 		ctx->y += n->d * 10;
-		ctx->y -= 5; /* off-grid */
-		/* TODO: - 5 again for loops with a backwards skip */
+
+		/* TODO: - 5 again for loops with a backwards skip (because they're short) */
+		if (n->u.comment.tnode->type == TNODE_VLIST
+		&& n->u.comment.tnode->u.vlist.o == 0
+		&& n->u.comment.tnode->u.vlist.n == 2
+		&& (n->u.comment.tnode->u.vlist.a[1]->type == TNODE_SKIP || n->u.comment.tnode->u.vlist.a[1]->type == TNODE_RTL_ARROW || n->u.comment.tnode->u.vlist.a[1]->type == TNODE_LTR_ARROW)) {
+			offset += 10;
+		}
+
+		ctx->y -= offset; /* off-grid */
 		svg_text(ctx, n->w * 10, n->u.comment.s, "comment");
-		ctx->y += 5;
+		ctx->y += offset;
 		ctx->y -= n->d * 10;
 		justify(ctx, n->u.comment.tnode, n->w * 10, base);
 		break;
+	}
 
 	case TNODE_RULE:
 		if (base != NULL) {


### PR DESCRIPTION
These `TNODE_COMMENT` texts are rendered below an arbitrary node. This avoids the special-case handling I found cumbersome, where labels for loops were known to the renderer for loops specifically.

The vertical offset is adjusted a little for short nodes.

![image](https://user-images.githubusercontent.com/1371085/52974349-1bce9300-33b9-11e9-88bb-005e16b1f1ed.png)