### PR TITLE
Add binary literals

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 .include "../share/mk/top.mk"
 
 SRC += src/ast.c
+SRC += src/ast_binary.c
 SRC += src/bitmap.c
 SRC += src/main.c
 SRC += src/rewrite_ci.c
@@ -16,6 +17,7 @@ PROG += kgt
 LFLAGS.kgt += -lm
 
 ${BUILD}/bin/kgt: ${BUILD}/src/ast.o
+${BUILD}/bin/kgt: ${BUILD}/src/ast_binary.o
 ${BUILD}/bin/kgt: ${BUILD}/src/bitmap.o
 ${BUILD}/bin/kgt: ${BUILD}/src/main.o
 ${BUILD}/bin/kgt: ${BUILD}/src/rewrite_ci.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,7 @@ SRC += src/ast_binary.c
 SRC += src/bitmap.c
 SRC += src/main.c
 SRC += src/rewrite_ci.c
+SRC += src/txt.c
 SRC += src/xalloc.c
 
 PROG += kgt
@@ -21,6 +22,7 @@ ${BUILD}/bin/kgt: ${BUILD}/src/ast_binary.o
 ${BUILD}/bin/kgt: ${BUILD}/src/bitmap.o
 ${BUILD}/bin/kgt: ${BUILD}/src/main.o
 ${BUILD}/bin/kgt: ${BUILD}/src/rewrite_ci.o
+${BUILD}/bin/kgt: ${BUILD}/src/txt.o
 ${BUILD}/bin/kgt: ${BUILD}/src/xalloc.o
 
 .for part in ${PART:Mbnf} ${PART:Mblab} ${PART:Mabnf} ${PART:Miso-ebnf} ${PART:Mrbnf} \

--- a/src/abnf/parser.c
+++ b/src/abnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 99 "src/parser.act"
+#line 102 "src/parser.act"
 
 
 	#include <assert.h>
@@ -21,6 +21,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
 
@@ -55,6 +56,7 @@
 
 	typedef char         map_char;
 	typedef const char * map_string;
+	typedef struct txt   map_txt;
 	typedef unsigned int map_count;
 
 	typedef struct ast_term * map_term;
@@ -87,6 +89,27 @@
 	extern int allow_undefined;
 
 	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
+
+		assert(lex_state != NULL);
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+
+		return s;
+	}
+
+	static const char *
 	prefix(int base)
 	{
 		switch (base) {
@@ -99,10 +122,13 @@
 	}
 
 	static int
-	string(const char *p, char *q, int base)
+	string(const char *p, struct txt *t, int base)
 	{
+		char *q;
+
 		assert(p != NULL);
-		assert(q != NULL);
+		assert(t != NULL);
+		assert(t->p != NULL);
 		assert(base > 0);
 
 		{
@@ -116,6 +142,8 @@
 
 			p += z;
 		}
+
+		q = t->p;
 
 		for (;;) {
 			unsigned long n;
@@ -142,8 +170,7 @@
 			p = e + 1;
 		}
 
-		/* XXX: need to support \0 in strings */
-		*q = '\0';
+		t->n = q - t->p;
 
 		return 0;
 	}
@@ -259,7 +286,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 263 "src/abnf/parser.c"
+#line 290 "src/abnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -276,13 +303,13 @@ static void prod_list_Hof_Halts(lex_state, act_state, map_alt *);
 static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
-static void prod_86(lex_state, act_state, map_count *);
-static void prod_100(lex_state, act_state, map_rule *);
-static void prod_101(lex_state, act_state, map_term *, map_alt *);
-static void prod_102(lex_state, act_state, map_term *);
-static void prod_104(lex_state, act_state, map_count *, map_term *);
+static void prod_87(lex_state, act_state, map_count *);
+static void prod_101(lex_state, act_state, map_rule *);
+static void prod_102(lex_state, act_state, map_term *, map_alt *);
+static void prod_103(lex_state, act_state, map_term *);
 static void prod_factor_C_Celement(lex_state, act_state, map_term *);
-static void prod_105(lex_state, act_state, map_term *);
+static void prod_105(lex_state, act_state, map_count *, map_term *);
+static void prod_106(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -297,20 +324,20 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 	switch (CURRENT_TERMINAL) {
 	case (TOK_COUNT):
 		{
-			map_count ZI103;
+			map_count ZI104;
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 327 "src/parser.act"
+#line 361 "src/parser.act"
 
-		ZI103 = strtoul(lex_state->buf.a, NULL, 10);
+		ZI104 = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 310 "src/abnf/parser.c"
+#line 337 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
-			prod_104 (lex_state, act_state, &ZI103, &ZIt);
+			prod_105 (lex_state, act_state, &ZI104, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -331,12 +358,12 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 498 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 340 "src/abnf/parser.c"
+#line 367 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			switch (CURRENT_TERMINAL) {
@@ -348,29 +375,29 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 356 "src/abnf/parser.c"
+#line 383 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 503 "src/parser.act"
+#line 539 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 368 "src/abnf/parser.c"
+#line 395 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
 		break;
-	case (TOK_STARTGROUP): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE):
-	case (TOK_CHAR): case (TOK_IDENT): case (TOK_BINSTR): case (TOK_DECSTR):
+	case (TOK_STARTGROUP): case (TOK_CHAR): case (TOK_IDENT): case (TOK_CI__LITERAL):
+	case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_BINSTR): case (TOK_DECSTR):
 	case (TOK_HEXSTR): case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
 			prod_factor_C_Celement (lex_state, act_state, &ZIt);
@@ -383,21 +410,21 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 	case (TOK_REP):
 		{
 			map_count ZImin;
-			map_count ZI85;
+			map_count ZI86;
 			map_count ZImax;
 
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 493 "src/parser.act"
+#line 529 "src/parser.act"
 
 		(ZImin) = 0;
-		(ZI85) = 0;
+		(ZI86) = 0;
 	
-#line 397 "src/abnf/parser.c"
+#line 424 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			ADVANCE_LEXER;
-			prod_86 (lex_state, act_state, &ZImax);
+			prod_87 (lex_state, act_state, &ZImax);
 			prod_factor_C_Celement (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -405,14 +432,14 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 503 "src/parser.act"
+#line 539 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 416 "src/abnf/parser.c"
+#line 443 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -456,21 +483,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 614 "src/parser.act"
+#line 650 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 464 "src/abnf/parser.c"
+#line 491 "src/abnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 661 "src/parser.act"
+#line 697 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 474 "src/abnf/parser.c"
+#line 501 "src/abnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -488,7 +515,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_102 (lex_state, act_state, &ZIl);
+		prod_103 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -512,7 +539,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_100 (lex_state, act_state, &ZIl);
+		prod_101 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -538,7 +565,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_101 (lex_state, act_state, &ZIt, &ZIl);
+		prod_102 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -568,13 +595,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 306 "src/parser.act"
+#line 340 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 578 "src/abnf/parser.c"
+#line 605 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -587,12 +614,12 @@ ZL2_body:;
 			/* END OF INLINE: 75 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 465 "src/parser.act"
+#line 519 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 596 "src/abnf/parser.c"
+#line 623 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -619,11 +646,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 	switch (CURRENT_TERMINAL) {
 	case (TOK_IDENT):
 		{
-			map_string ZIs;
+			map_string ZIx;
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 319 "src/parser.act"
+#line 353 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -634,19 +661,19 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		 */
 		rtrim(lex_state->buf.a);
 
-		ZIs = xstrdup(lex_state->buf.a);
-		if (ZIs == NULL) {
+		ZIx = xstrdup(lex_state->buf.a);
+		if (ZIx == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 	
-#line 644 "src/abnf/parser.c"
+#line 671 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 542 "src/parser.act"
+#line 578 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -656,7 +683,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		 * at which to point. This saves passing the grammar around, which
 		 * keeps the rule-building productions simpler.
 		 */
-		r = ast_make_rule((ZIs), NULL);
+		r = ast_make_rule((ZIx), NULL);
 		if (r == NULL) {
 			perror("ast_make_rule");
 			goto ZL1;
@@ -664,15 +691,15 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 668 "src/abnf/parser.c"
+#line 695 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
 		break;
-	case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR):
+	case (TOK_CHAR): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE):
 		{
 			prod_body (lex_state, act_state);
-			prod_105 (lex_state, act_state, &ZIt);
+			prod_106 (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -691,7 +718,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: BINRANGE */
 						{
-#line 412 "src/parser.act"
+#line 466 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, &ZIm, &ZIn,  2)) {
 			if (errno == ERANGE) {
@@ -703,7 +730,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 707 "src/abnf/parser.c"
+#line 734 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: BINRANGE */
 						ADVANCE_LEXER;
@@ -713,7 +740,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: DECRANGE */
 						{
-#line 436 "src/parser.act"
+#line 490 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, &ZIm, &ZIn, 10)) {
 			if (errno == ERANGE) {
@@ -725,7 +752,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 729 "src/abnf/parser.c"
+#line 756 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: DECRANGE */
 						ADVANCE_LEXER;
@@ -735,7 +762,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: HEXRANGE */
 						{
-#line 448 "src/parser.act"
+#line 502 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, &ZIm, &ZIn, 16)) {
 			if (errno == ERANGE) {
@@ -747,7 +774,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 751 "src/abnf/parser.c"
+#line 778 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: HEXRANGE */
 						ADVANCE_LEXER;
@@ -760,7 +787,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			/* END OF INLINE: escrange */
 			/* BEGINNING OF ACTION: make-range-term */
 			{
-#line 590 "src/parser.act"
+#line 626 "src/parser.act"
 
 		struct ast_alt *a;
 		int i;
@@ -780,14 +807,14 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_group_term(a);
 	
-#line 784 "src/abnf/parser.c"
+#line 811 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-range-term */
 		}
 		break;
 	case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
 		{
-			map_string ZIs;
+			map_txt ZIx;
 
 			/* BEGINNING OF INLINE: escstr */
 			{
@@ -796,15 +823,15 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: BINSTR */
 						{
-#line 332 "src/parser.act"
+#line 386 "src/parser.act"
 
-		ZIs = xstrdup(lex_state->buf.a);
-		if (ZIs == NULL) {
+		ZIx.p = xstrdup(lex_state->buf.a);
+		if (ZIx.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, ZIs,  2)) {
+		if (-1 == string(lex_state->buf.a, &ZIx,  2)) {
 			if (errno == ERANGE) {
 				err(lex_state, "binary sequence %s out of range: expected %s0..%s%s inclusive",
 					lex_state->buf.a, prefix(2), prefix(2), "11111111");
@@ -816,7 +843,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 820 "src/abnf/parser.c"
+#line 847 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: BINSTR */
 						ADVANCE_LEXER;
@@ -826,15 +853,15 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: DECSTR */
 						{
-#line 372 "src/parser.act"
+#line 426 "src/parser.act"
 
-		ZIs = xstrdup(lex_state->buf.a);
-		if (ZIs == NULL) {
+		ZIx.p = xstrdup(lex_state->buf.a);
+		if (ZIx.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, ZIs, 10)) {
+		if (-1 == string(lex_state->buf.a, &ZIx, 10)) {
 			if (errno == ERANGE) {
 				err(lex_state, "decimal sequence %s out of range: expected %s0..%s%u inclusive",
 					lex_state->buf.a, prefix(10), prefix(10), UCHAR_MAX);
@@ -846,7 +873,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 850 "src/abnf/parser.c"
+#line 877 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: DECSTR */
 						ADVANCE_LEXER;
@@ -856,15 +883,15 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: HEXSTR */
 						{
-#line 392 "src/parser.act"
+#line 446 "src/parser.act"
 
-		ZIs = xstrdup(lex_state->buf.a);
-		if (ZIs == NULL) {
+		ZIx.p = xstrdup(lex_state->buf.a);
+		if (ZIx.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, ZIs, 16)) {
+		if (-1 == string(lex_state->buf.a, &ZIx, 16)) {
 			if (errno == ERANGE) {
 				err(lex_state, "hex sequence %s out of range: expected %s0..%s%x inclusive",
 					lex_state->buf.a, prefix(16), prefix(16), UCHAR_MAX);
@@ -876,7 +903,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 880 "src/abnf/parser.c"
+#line 907 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: HEXSTR */
 						ADVANCE_LEXER;
@@ -889,11 +916,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			/* END OF INLINE: escstr */
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 563 "src/parser.act"
+#line 599 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term((ZIs), 0);
+		(ZIt) = ast_make_literal_term(&(ZIx), 0);
 	
-#line 897 "src/abnf/parser.c"
+#line 924 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -926,7 +953,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 319 "src/parser.act"
+#line 353 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -943,7 +970,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 947 "src/abnf/parser.c"
+#line 974 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -951,14 +978,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 94 */
+		/* BEGINNING OF INLINE: 95 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EQUALS):
 				{
 					map_alt ZIa;
 
-					/* BEGINNING OF INLINE: 95 */
+					/* BEGINNING OF INLINE: 96 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
@@ -974,17 +1001,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 						{
 							/* BEGINNING OF ACTION: err-expected-equals */
 							{
-#line 673 "src/parser.act"
+#line 709 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 982 "src/abnf/parser.c"
+#line 1009 "src/abnf/parser.c"
 							}
 							/* END OF ACTION: err-expected-equals */
 						}
 					ZL3:;
 					}
-					/* END OF INLINE: 95 */
+					/* END OF INLINE: 96 */
 					prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
@@ -992,11 +1019,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					}
 					/* BEGINNING OF ACTION: make-rule */
 					{
-#line 610 "src/parser.act"
+#line 646 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 1000 "src/abnf/parser.c"
+#line 1027 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: make-rule */
 				}
@@ -1006,7 +1033,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					map_rule ZIl;
 					map_alt ZIa;
 
-					/* BEGINNING OF INLINE: 96 */
+					/* BEGINNING OF INLINE: 97 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
@@ -1022,26 +1049,26 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 						{
 							/* BEGINNING OF ACTION: err-expected-equals */
 							{
-#line 673 "src/parser.act"
+#line 709 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 1030 "src/abnf/parser.c"
+#line 1057 "src/abnf/parser.c"
 							}
 							/* END OF ACTION: err-expected-equals */
 						}
 					ZL5:;
 					}
-					/* END OF INLINE: 96 */
+					/* END OF INLINE: 97 */
 					/* BEGINNING OF ACTION: current-rules */
 					{
-#line 642 "src/parser.act"
+#line 678 "src/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		(ZIl) = NULL;
 		goto ZL1;
 	
-#line 1045 "src/abnf/parser.c"
+#line 1072 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: current-rules */
 					prod_list_Hof_Halts (lex_state, act_state, &ZIa);
@@ -1051,23 +1078,23 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					}
 					/* BEGINNING OF ACTION: find-rule */
 					{
-#line 647 "src/parser.act"
+#line 683 "src/parser.act"
 
 		assert((ZIs) != NULL);
 
 		(ZIr) = ast_find_rule((ZIl), (ZIs));
 	
-#line 1061 "src/abnf/parser.c"
+#line 1088 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: find-rule */
 					/* BEGINNING OF ACTION: add-alts */
 					{
-#line 654 "src/parser.act"
+#line 690 "src/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		goto ZL1;
 	
-#line 1071 "src/abnf/parser.c"
+#line 1098 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: add-alts */
 				}
@@ -1076,8 +1103,8 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 94 */
-		/* BEGINNING OF INLINE: 97 */
+		/* END OF INLINE: 95 */
+		/* BEGINNING OF INLINE: 98 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EOF):
@@ -1098,17 +1125,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 669 "src/parser.act"
+#line 705 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 1106 "src/abnf/parser.c"
+#line 1133 "src/abnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL7:;
 		}
-		/* END OF INLINE: 97 */
+		/* END OF INLINE: 98 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1119,7 +1146,7 @@ ZL0:;
 }
 
 static void
-prod_86(lex_state lex_state, act_state act_state, map_count *ZOmax)
+prod_87(lex_state lex_state, act_state act_state, map_count *ZOmax)
 {
 	map_count ZImax;
 
@@ -1128,12 +1155,12 @@ prod_86(lex_state lex_state, act_state act_state, map_count *ZOmax)
 		{
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 327 "src/parser.act"
+#line 361 "src/parser.act"
 
 		ZImax = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 1137 "src/abnf/parser.c"
+#line 1164 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -1141,16 +1168,16 @@ prod_86(lex_state lex_state, act_state act_state, map_count *ZOmax)
 		break;
 	default:
 		{
-			map_count ZI88;
+			map_count ZI89;
 
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 493 "src/parser.act"
+#line 529 "src/parser.act"
 
-		(ZI88) = 0;
+		(ZI89) = 0;
 		(ZImax) = 0;
 	
-#line 1154 "src/abnf/parser.c"
+#line 1181 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 		}
@@ -1162,7 +1189,7 @@ prod_86(lex_state lex_state, act_state act_state, map_count *ZOmax)
 }
 
 static void
-prod_100(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_101(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_IDENT):
@@ -1176,7 +1203,7 @@ prod_100(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 629 "src/parser.act"
+#line 665 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -1188,7 +1215,7 @@ prod_100(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 1192 "src/abnf/parser.c"
+#line 1219 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -1205,7 +1232,7 @@ ZL1:;
 }
 
 static void
-prod_101(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_102(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -1214,7 +1241,7 @@ prod_101(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 91 */
+			/* BEGINNING OF INLINE: 92 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -1230,17 +1257,17 @@ prod_101(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 665 "src/parser.act"
+#line 701 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 1238 "src/abnf/parser.c"
+#line 1265 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 91 */
+			/* END OF INLINE: 92 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1248,21 +1275,21 @@ prod_101(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1256 "src/abnf/parser.c"
+#line 1283 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 624 "src/parser.act"
+#line 660 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1266 "src/abnf/parser.c"
+#line 1293 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1271,11 +1298,11 @@ prod_101(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1279 "src/abnf/parser.c"
+#line 1306 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1292,12 +1319,12 @@ ZL0:;
 }
 
 static void
-prod_102(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_103(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
-	case (TOK_REP): case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_CI__LITERAL):
-	case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR): case (TOK_IDENT):
-	case (TOK_COUNT): case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
+	case (TOK_REP): case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_CHAR):
+	case (TOK_IDENT): case (TOK_COUNT): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL):
+	case (TOK_PROSE): case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
 	case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
 			map_term ZIt;
@@ -1309,12 +1336,12 @@ prod_102(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 619 "src/parser.act"
+#line 655 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1318 "src/abnf/parser.c"
+#line 1345 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1328,73 +1355,6 @@ prod_102(lex_state lex_state, act_state act_state, map_term *ZIl)
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-}
-
-static void
-prod_104(lex_state lex_state, act_state act_state, map_count *ZI103, map_term *ZOt)
-{
-	map_term ZIt;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_REP):
-		{
-			map_count ZImax;
-
-			ADVANCE_LEXER;
-			prod_86 (lex_state, act_state, &ZImax);
-			prod_factor_C_Celement (lex_state, act_state, &ZIt);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: set-repeat */
-			{
-#line 503 "src/parser.act"
-
-		assert((ZImax) >= (*ZI103) || !(ZImax));
-
-		(ZIt)->min = (*ZI103);
-		(ZIt)->max = (ZImax);
-	
-#line 1360 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: set-repeat */
-		}
-		break;
-	case (TOK_STARTGROUP): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE):
-	case (TOK_CHAR): case (TOK_IDENT): case (TOK_BINSTR): case (TOK_DECSTR):
-	case (TOK_HEXSTR): case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
-		{
-			prod_factor_C_Celement (lex_state, act_state, &ZIt);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: set-repeat */
-			{
-#line 503 "src/parser.act"
-
-		assert((*ZI103) >= (*ZI103) || !(*ZI103));
-
-		(ZIt)->min = (*ZI103);
-		(ZIt)->max = (*ZI103);
-	
-#line 1383 "src/abnf/parser.c"
-			}
-			/* END OF ACTION: set-repeat */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOt = ZIt;
 }
 
 static void
@@ -1421,17 +1381,17 @@ prod_factor_C_Celement(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 1429 "src/abnf/parser.c"
+#line 1389 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
 		break;
-	case (TOK_CI__LITERAL): case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR):
-	case (TOK_IDENT): case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
+	case (TOK_CHAR): case (TOK_IDENT): case (TOK_CI__LITERAL): case (TOK_CS__LITERAL):
+	case (TOK_PROSE): case (TOK_BINSTR): case (TOK_DECSTR): case (TOK_HEXSTR):
 	case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
 		{
 			prod_term (lex_state, act_state, &ZIt);
@@ -1455,92 +1415,133 @@ ZL0:;
 }
 
 static void
-prod_105(lex_state lex_state, act_state act_state, map_term *ZOt)
+prod_105(lex_state lex_state, act_state act_state, map_count *ZI104, map_term *ZOt)
+{
+	map_term ZIt;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_REP):
+		{
+			map_count ZImax;
+
+			ADVANCE_LEXER;
+			prod_87 (lex_state, act_state, &ZImax);
+			prod_factor_C_Celement (lex_state, act_state, &ZIt);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			/* BEGINNING OF ACTION: set-repeat */
+			{
+#line 539 "src/parser.act"
+
+		assert((ZImax) >= (*ZI104) || !(ZImax));
+
+		(ZIt)->min = (*ZI104);
+		(ZIt)->max = (ZImax);
+	
+#line 1444 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: set-repeat */
+		}
+		break;
+	case (TOK_STARTGROUP): case (TOK_CHAR): case (TOK_IDENT): case (TOK_CI__LITERAL):
+	case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_BINSTR): case (TOK_DECSTR):
+	case (TOK_HEXSTR): case (TOK_BINRANGE): case (TOK_DECRANGE): case (TOK_HEXRANGE):
+		{
+			prod_factor_C_Celement (lex_state, act_state, &ZIt);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			/* BEGINNING OF ACTION: set-repeat */
+			{
+#line 539 "src/parser.act"
+
+		assert((*ZI104) >= (*ZI104) || !(*ZI104));
+
+		(ZIt)->min = (*ZI104);
+		(ZIt)->max = (*ZI104);
+	
+#line 1467 "src/abnf/parser.c"
+			}
+			/* END OF ACTION: set-repeat */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOt = ZIt;
+}
+
+static void
+prod_106(lex_state lex_state, act_state act_state, map_term *ZOt)
 {
 	map_term ZIt;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CI__LITERAL):
 		{
-			map_string ZIs;
+			map_txt ZIx;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: CI_LITERAL */
 			{
-#line 477 "src/parser.act"
+#line 371 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIx.p = pattern_buffer(lex_state);
+		ZIx.n = strlen(ZIx.p);
 	
-#line 1489 "src/abnf/parser.c"
+#line 1502 "src/abnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: CI_LITERAL */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-ci-literal-term */
 			{
-#line 555 "src/parser.act"
+#line 591 "src/parser.act"
 
-		char *p;
+		size_t i;
 
 		/* normalise case-insensitive strings for aesthetic reasons only */
-		for (p = (ZIs); *p != '\0'; p++) {
-			*p = tolower((unsigned char) *p);
+		for (i = 0; i < (ZIx).n; i++) {
+			((char *) (ZIx).p)[i] = tolower((unsigned char) (ZIx).p[i]);
 		}
 
-		(ZIt) = ast_make_literal_term((ZIs), 1);
+		(ZIt) = ast_make_literal_term(&(ZIx), 1);
 	
-#line 1505 "src/abnf/parser.c"
+#line 1519 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-ci-literal-term */
 		}
 		break;
 	case (TOK_CS__LITERAL):
 		{
-			map_string ZIs;
+			map_txt ZIx;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: CS_LITERAL */
 			{
-#line 477 "src/parser.act"
+#line 376 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIx.p = pattern_buffer(lex_state);
+		ZIx.n = strlen(ZIx.p);
 	
 #line 1535 "src/abnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: CS_LITERAL */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 563 "src/parser.act"
+#line 599 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term((ZIs), 0);
+		(ZIt) = ast_make_literal_term(&(ZIx), 0);
 	
-#line 1544 "src/abnf/parser.c"
+#line 1545 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -1549,33 +1550,19 @@ prod_105(lex_state lex_state, act_state act_state, map_term *ZOt)
 		{
 			map_string ZIs;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: PROSE */
 			{
-#line 477 "src/parser.act"
+#line 381 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIs = pattern_buffer(lex_state);
 	
-#line 1574 "src/abnf/parser.c"
+#line 1560 "src/abnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: PROSE */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-prose-term */
 			{
-#line 573 "src/parser.act"
+#line 609 "src/parser.act"
 
 		const char *s;
 
@@ -1585,7 +1572,7 @@ prod_105(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		free((ZIs));
 	
-#line 1589 "src/abnf/parser.c"
+#line 1576 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-prose-term */
 		}
@@ -1605,7 +1592,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 807 "src/parser.act"
+#line 843 "src/parser.act"
 
 
 	static int
@@ -1734,6 +1721,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1738 "src/abnf/parser.c"
+#line 1725 "src/abnf/parser.c"
 
 /* END OF FILE */

--- a/src/abnf/parser.c
+++ b/src/abnf/parser.c
@@ -794,7 +794,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		a = NULL;
 
-		for (i = (ZIm); i <= (ZIn); i++) {
+		for (i = (unsigned char) (ZIm); i <= (unsigned char) (ZIn); i++) {
 			struct ast_alt *new;
 			struct ast_term *t;
 

--- a/src/abnf/parser.h
+++ b/src/abnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 287 "src/parser.act"
+#line 315 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_abnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 809 "src/parser.act"
+#line 845 "src/parser.act"
 
 
 #line 31 "src/abnf/parser.h"

--- a/src/abnf/parser.sid
+++ b/src/abnf/parser.sid
@@ -39,7 +39,7 @@
 	!NAME;
 	CI_LITERAL;
 	CS_LITERAL;
-	!PROSE;
+	PROSE;
 
 	!ESC:  () -> (:char);
 	CHAR:  () -> (:char);
@@ -73,7 +73,7 @@
 	<make-ci-literal-term>: (:string)      -> (:ast_term);
 	<make-cs-literal-term>: (:string)      -> (:ast_term);
 	!<make-token-term>:     (:string)      -> (:ast_term);
-	!<make-prose-term>:     (:string)      -> (:ast_term);
+	<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:      (:ast_alt)     -> (:ast_term);
 	<make-range-term>:      (:char, :char) -> (:ast_term);
 

--- a/src/abnf/parser.sid
+++ b/src/abnf/parser.sid
@@ -35,16 +35,16 @@
 	STARTOPT;   ENDOPT;
 	!STARTSTAR; !ENDSTAR;
 
-	!EMPTY;
-	!NAME;
-	CI_LITERAL;
-	CS_LITERAL;
-	PROSE;
-
 	!ESC:  () -> (:char);
 	CHAR:  () -> (:char);
 	IDENT: () -> (:string);
 	COUNT: () -> (:count);
+
+	!EMPTY;
+	!NAME:      () -> (:string);
+	CI_LITERAL: () -> (:string);
+	CS_LITERAL: () -> (:string);
+	PROSE:      () -> (:string);
 
 	BINSTR:   () -> (:string);
 	!OCTSTR:  () -> (:string);
@@ -59,7 +59,6 @@
 %productions%
 
 	<pattern-char>:   (:char) -> ();
-	<pattern-buffer>: ()      -> (:string);
 
 	!<rep-one-or-more>: () -> (:count, :count);
 	<rep-zero-or-more>: () -> (:count, :count);
@@ -126,18 +125,15 @@
 
 	term: () -> (t :ast_term) = {
 		body;
-		CI_LITERAL;
-		s = <pattern-buffer>;
+		s = CI_LITERAL;
 		t = <make-ci-literal-term>(s);
 	||
 		body;
-		CS_LITERAL;
-		s = <pattern-buffer>;
+		s = CS_LITERAL;
 		t = <make-cs-literal-term>(s);
 	||
 		body;
-		PROSE;
-		s = <pattern-buffer>;
+		s = PROSE;
 		t = <make-prose-term>(s);
 	||
 		s = IDENT;

--- a/src/abnf/parser.sid
+++ b/src/abnf/parser.sid
@@ -12,6 +12,7 @@
 
 	char;
 	string;
+	txt;
 	count;
 
 	ast_rule;
@@ -42,14 +43,14 @@
 
 	!EMPTY;
 	!NAME:      () -> (:string);
-	CI_LITERAL: () -> (:string);
-	CS_LITERAL: () -> (:string);
+	CI_LITERAL: () -> (:txt);
+	CS_LITERAL: () -> (:txt);
 	PROSE:      () -> (:string);
 
-	BINSTR:   () -> (:string);
-	!OCTSTR:  () -> (:string);
-	DECSTR:   () -> (:string);
-	HEXSTR:   () -> (:string);
+	BINSTR:   () -> (:txt);
+	!OCTSTR:  () -> (:txt);
+	DECSTR:   () -> (:txt);
+	HEXSTR:   () -> (:txt);
 
 	BINRANGE:  () -> (:char, :char);
 	!OCTRANGE: () -> (:char, :char);
@@ -69,8 +70,8 @@
 
 	!<make-empty-term>:     ()             -> (:ast_term);
 	<make-rule-term>:       (:string)      -> (:ast_term);
-	<make-ci-literal-term>: (:string)      -> (:ast_term);
-	<make-cs-literal-term>: (:string)      -> (:ast_term);
+	<make-ci-literal-term>: (:txt)         -> (:ast_term);
+	<make-cs-literal-term>: (:txt)         -> (:ast_term);
 	!<make-token-term>:     (:string)      -> (:ast_term);
 	<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:      (:ast_alt)     -> (:ast_term);
@@ -96,12 +97,12 @@
 
 	list-of-alts: () -> (:ast_alt);
 
-	escstr: () -> (s :string) = {
-		s = BINSTR;
+	escstr: () -> (x :txt) = {
+		x = BINSTR;
 	||
-		s = DECSTR;
+		x = DECSTR;
 	||
-		s = HEXSTR;
+		x = HEXSTR;
 	};
 
 	escrange: () -> (m :char, n :char) = {
@@ -125,23 +126,23 @@
 
 	term: () -> (t :ast_term) = {
 		body;
-		s = CI_LITERAL;
-		t = <make-ci-literal-term>(s);
+		x = CI_LITERAL;
+		t = <make-ci-literal-term>(x);
 	||
 		body;
-		s = CS_LITERAL;
-		t = <make-cs-literal-term>(s);
+		x = CS_LITERAL;
+		t = <make-cs-literal-term>(x);
 	||
 		body;
 		s = PROSE;
 		t = <make-prose-term>(s);
 	||
-		s = IDENT;
+		x = IDENT;
 /* TODO: case insensitive */
-		t = <make-rule-term>(s);
+		t = <make-rule-term>(x);
 	||
-		s = escstr;
-		t = <make-cs-literal-term>(s);
+		x = escstr;
+		t = <make-cs-literal-term>(x);
 	||
 		(m, n) = escrange;
 		t = <make-range-term>(m, n);

--- a/src/ast.c
+++ b/src/ast.c
@@ -9,18 +9,20 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+#include "txt.h"
 #include "ast.h"
 #include "xalloc.h"
 
 static int
-isalphastr(const char *s)
+isalphastr(const struct txt *t)
 {
-	const char *p;
+	size_t i;
 
-	assert(s != NULL);
+	assert(t != NULL);
+	assert(t->p != NULL);
 
-	for (p = s; *p != '\0'; p++) {
-		if (isalpha((unsigned char) *p)) {
+	for (i = 0; i < t->n; i++) {
+		if (isalpha((unsigned char) t->p[i])) {
 			return 1;
 		}
 	}
@@ -65,16 +67,16 @@ struct ast_term *
 ast_make_char_term(char c)
 {
 	struct ast_term *new;
-	char *s;
+	char *a;
 
-	s = xmalloc(2); /* XXX: i don't like this */
-	s[0] = c;
-	s[1] = '\0';
+	a = xmalloc(1); /* XXX: i don't like this */
+	a[0] = c;
 
 	new = xmalloc(sizeof *new);
-	new->type      = TYPE_CS_LITERAL;
-	new->next      = NULL;
-	new->u.literal = s;
+	new->type        = TYPE_CS_LITERAL;
+	new->next        = NULL;
+	new->u.literal.p = a;
+	new->u.literal.n = 1;
 
 	new->min = 1;
 	new->max = 1;
@@ -83,19 +85,20 @@ ast_make_char_term(char c)
 }
 
 struct ast_term *
-ast_make_literal_term(const char *literal, int ci)
+ast_make_literal_term(const struct txt *literal, int ci)
 {
 	struct ast_term *new;
 
 	assert(literal != NULL);
+	assert(literal->p != NULL);
 
 	new = xmalloc(sizeof *new);
 	new->type      = ci ? TYPE_CI_LITERAL : TYPE_CS_LITERAL;
 	new->next      = NULL;
-	new->u.literal = literal;
+	new->u.literal = *literal;
 
 	/* no need for case-insensitive strings if there are no letters */
-	if (!isalphastr(new->u.literal)) {
+	if (!isalphastr(&new->u.literal)) {
 		new->type = TYPE_CS_LITERAL;
 	}
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -36,7 +36,7 @@ struct ast_term {
 
 	union {
 		const struct ast_rule *rule; /* just for sake of the name */
-		const char *literal;
+		struct txt literal;
 		const char *token;
 		const char *prose;
 		struct ast_alt *group;
@@ -84,7 +84,7 @@ struct ast_term *
 ast_make_char_term(char c);
 
 struct ast_term *
-ast_make_literal_term(const char *literal, int ci);
+ast_make_literal_term(const struct txt *literal, int ci);
 
 struct ast_term *
 ast_make_token_term(const char *token);

--- a/src/ast.h
+++ b/src/ast.h
@@ -11,7 +11,8 @@ struct ast_alt;
 
 enum ast_features {
     FEATURE_AST_CI_LITERAL = 1 << 0,
-    FEATURE_AST_PROSE      = 1 << 1
+    FEATURE_AST_PROSE      = 1 << 1,
+    FEATURE_AST_BINARY     = 1 << 2
 };
 
 /*
@@ -105,6 +106,9 @@ ast_find_rule(const struct ast_rule *grammar, const char *name);
 
 void
 ast_free_rule(struct ast_rule *rule);
+
+int
+ast_binary(const struct ast_rule *ast);
 
 #endif
 

--- a/src/ast_binary.c
+++ b/src/ast_binary.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <ctype.h>
+
+#include "ast.h"
+
+static int
+walk_term(const struct ast_term *term);
+
+static int
+walk_alts(const struct ast_alt *alts)
+{
+	const struct ast_alt *p;
+	const struct ast_term *q;
+
+	for (p = alts; p != NULL; p = p->next) {
+		for (q = p->terms; q != NULL; q = q->next) {
+			if (walk_term(q)) {
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int
+binary_literal(const char *s)
+{
+	const char *p;
+
+	for (p = s; *p != '\0'; p++) {
+		if (!isprint((unsigned char) *p)) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static int
+walk_term(const struct ast_term *term)
+{
+	switch (term->type) {
+	case TYPE_EMPTY:
+	case TYPE_RULE:
+	case TYPE_TOKEN:
+	case TYPE_PROSE:
+		return 0;
+
+	case TYPE_CI_LITERAL:
+	case TYPE_CS_LITERAL:
+		return binary_literal(term->u.literal);
+
+	case TYPE_GROUP:
+		return walk_alts(term->u.group);
+	}
+}
+
+int
+ast_binary(const struct ast_rule *ast)
+{
+	return walk_alts(ast->alts);
+}
+

--- a/src/ast_binary.c
+++ b/src/ast_binary.c
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <ctype.h>
 
+#include "txt.h"
 #include "ast.h"
 
 static int
@@ -31,12 +32,14 @@ walk_alts(const struct ast_alt *alts)
 }
 
 static int
-binary_literal(const char *s)
+binary_literal(const struct txt *t)
 {
-	const char *p;
+	size_t i;
 
-	for (p = s; *p != '\0'; p++) {
-		if (!isprint((unsigned char) *p)) {
+	assert(t != NULL);
+
+	for (i = 0; i < t->n; i++) {
+		if (!isprint((unsigned char) t->p[i])) {
 			return 1;
 		}
 	}
@@ -56,7 +59,7 @@ walk_term(const struct ast_term *term)
 
 	case TYPE_CI_LITERAL:
 	case TYPE_CS_LITERAL:
-		return binary_literal(term->u.literal);
+		return binary_literal(&term->u.literal);
 
 	case TYPE_GROUP:
 		return walk_alts(term->u.group);

--- a/src/blab/output.c
+++ b/src/blab/output.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "io.h"
@@ -139,21 +140,21 @@ output_term(const struct ast_term *term)
 		break;
 
 	case TYPE_CI_LITERAL: {
-			const char *p;
+			size_t i;
 
 			putc(' ', stdout);
 
 			/* XXX: the tokenization here is wrong; this should be a single token */
 
-			for (p = term->u.literal; *p != '\0'; p++) {
+			for (i = 0; i < term->u.literal.n; i++) {
 				char uc, lc;
 
-				uc = toupper((unsigned char) *p);
-				lc = tolower((unsigned char) *p);
+				uc = toupper((unsigned char) term->u.literal.p[i]);
+				lc = tolower((unsigned char) term->u.literal.p[i]);
 
 				if (uc == lc) {
 					putc('[', stdout);
-					(void) blab_escputc(stdout, *p);
+					(void) blab_escputc(stdout, term->u.literal.p[i]);
 					putc(']', stdout);
 					continue;
 				}
@@ -169,12 +170,12 @@ output_term(const struct ast_term *term)
 		break;
 
 	case TYPE_CS_LITERAL: {
-			const char *p;
+			size_t i;
 
 			fputs(" \"", stdout);
 
-			for (p = term->u.literal; *p != '\0'; p++) {
-				(void) blab_escputc(stdout, *p);
+			for (i = 0; i < term->u.literal.n; i++) {
+				(void) blab_escputc(stdout, term->u.literal.p[i]);
 			}
 
 			putc('\"', stdout);

--- a/src/bnf/io.h
+++ b/src/bnf/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define bnf_ast_unsupported FEATURE_AST_CI_LITERAL
+#define bnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
 
 struct ast_rule *
 bnf_input(int (*f)(void *opaque), void *opaque);

--- a/src/bnf/output.c
+++ b/src/bnf/output.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "io.h"
@@ -45,8 +46,8 @@ output_term(const struct ast_term *term)
 	case TYPE_CS_LITERAL: {
 			char c;
 
-			c = strchr(term->u.literal, '\"') ? '\'' : '\"';
-			printf(" %c%s%c", c, term->u.literal, c);
+			c = memchr(term->u.literal.p, '\"', term->u.literal.n) ? '\'' : '\"';
+			printf(" %c%.*s%c", c, (int) term->u.literal.n, term->u.literal.p, c);
 		}
 		break;
 

--- a/src/bnf/parser.c
+++ b/src/bnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 99 "src/parser.act"
+#line 102 "src/parser.act"
 
 
 	#include <assert.h>
@@ -21,6 +21,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
 
@@ -55,6 +56,7 @@
 
 	typedef char         map_char;
 	typedef const char * map_string;
+	typedef struct txt   map_txt;
 	typedef unsigned int map_count;
 
 	typedef struct ast_term * map_term;
@@ -87,6 +89,27 @@
 	extern int allow_undefined;
 
 	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
+
+		assert(lex_state != NULL);
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+
+		return s;
+	}
+
+	static const char *
 	prefix(int base)
 	{
 		switch (base) {
@@ -99,10 +122,13 @@
 	}
 
 	static int
-	string(const char *p, char *q, int base)
+	string(const char *p, struct txt *t, int base)
 	{
+		char *q;
+
 		assert(p != NULL);
-		assert(q != NULL);
+		assert(t != NULL);
+		assert(t->p != NULL);
 		assert(base > 0);
 
 		{
@@ -116,6 +142,8 @@
 
 			p += z;
 		}
+
+		q = t->p;
 
 		for (;;) {
 			unsigned long n;
@@ -142,8 +170,7 @@
 			p = e + 1;
 		}
 
-		/* XXX: need to support \0 in strings */
-		*q = '\0';
+		t->n = q - t->p;
 
 		return 0;
 	}
@@ -259,7 +286,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 263 "src/bnf/parser.c"
+#line 290 "src/bnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -276,10 +303,10 @@ static void prod_body(lex_state, act_state);
 extern void prod_bnf(lex_state, act_state, map_rule *);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
-static void prod_89(lex_state, act_state, map_rule *);
-static void prod_90(lex_state, act_state, map_term *, map_alt *);
-static void prod_91(lex_state, act_state, map_term *);
+static void prod_90(lex_state, act_state, map_rule *);
+static void prod_91(lex_state, act_state, map_term *, map_alt *);
 static void prod_92(lex_state, act_state, map_term *);
+static void prod_93(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -319,7 +346,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_91 (lex_state, act_state, &ZIl);
+		prod_92 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -343,7 +370,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_89 (lex_state, act_state, &ZIl);
+		prod_90 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -369,7 +396,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_90 (lex_state, act_state, &ZIt, &ZIl);
+		prod_91 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -399,13 +426,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 306 "src/parser.act"
+#line 340 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 409 "src/bnf/parser.c"
+#line 436 "src/bnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -418,12 +445,12 @@ ZL2_body:;
 			/* END OF INLINE: 68 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 465 "src/parser.act"
+#line 519 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 427 "src/bnf/parser.c"
+#line 454 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -462,21 +489,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 614 "src/parser.act"
+#line 650 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 470 "src/bnf/parser.c"
+#line 497 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 661 "src/parser.act"
+#line 697 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 480 "src/bnf/parser.c"
+#line 507 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -495,19 +522,19 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 530 "src/parser.act"
+#line 566 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term();
 	
-#line 503 "src/bnf/parser.c"
+#line 530 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
 		break;
-	case (TOK_NAME): case (TOK_CS__LITERAL): case (TOK_CHAR):
+	case (TOK_CHAR): case (TOK_NAME): case (TOK_CS__LITERAL):
 		{
 			prod_body (lex_state, act_state);
-			prod_92 (lex_state, act_state, &ZIt);
+			prod_93 (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -542,6 +569,15 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		prod_body (lex_state, act_state);
 		switch (CURRENT_TERMINAL) {
 		case (TOK_NAME):
+			/* BEGINNING OF EXTRACT: NAME */
+			{
+#line 367 "src/parser.act"
+
+		ZIs = pattern_buffer(lex_state);
+	
+#line 579 "src/bnf/parser.c"
+			}
+			/* END OF EXTRACT: NAME */
 			break;
 		case (ERROR_TERMINAL):
 			RESTORE_LEXER;
@@ -550,30 +586,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF ACTION: pattern-buffer */
-		{
-#line 477 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 574 "src/bnf/parser.c"
-		}
-		/* END OF ACTION: pattern-buffer */
-		/* BEGINNING OF INLINE: 81 */
+		/* BEGINNING OF INLINE: 82 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -589,17 +602,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 673 "src/parser.act"
+#line 709 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 597 "src/bnf/parser.c"
+#line 610 "src/bnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 81 */
+		/* END OF INLINE: 82 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -607,14 +620,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 610 "src/parser.act"
+#line 646 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 615 "src/bnf/parser.c"
+#line 628 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 82 */
+		/* BEGINNING OF INLINE: 83 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_EOF):
@@ -635,17 +648,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 669 "src/parser.act"
+#line 705 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 643 "src/bnf/parser.c"
+#line 656 "src/bnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 82 */
+		/* END OF INLINE: 83 */
 	}
 	goto ZL0;
 ZL1:;
@@ -656,10 +669,10 @@ ZL0:;
 }
 
 static void
-prod_89(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_90(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
-	case (TOK_NAME): case (TOK_CHAR):
+	case (TOK_CHAR): case (TOK_NAME):
 		{
 			map_rule ZIr;
 
@@ -670,7 +683,7 @@ prod_89(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 629 "src/parser.act"
+#line 665 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -682,7 +695,7 @@ prod_89(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 686 "src/bnf/parser.c"
+#line 699 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -699,7 +712,7 @@ ZL1:;
 }
 
 static void
-prod_90(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -708,7 +721,7 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 77 */
+			/* BEGINNING OF INLINE: 78 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -724,17 +737,17 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 665 "src/parser.act"
+#line 701 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 732 "src/bnf/parser.c"
+#line 745 "src/bnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 77 */
+			/* END OF INLINE: 78 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -742,21 +755,21 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 750 "src/bnf/parser.c"
+#line 763 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 624 "src/parser.act"
+#line 660 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 760 "src/bnf/parser.c"
+#line 773 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -765,11 +778,11 @@ prod_90(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 773 "src/bnf/parser.c"
+#line 786 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -786,10 +799,10 @@ ZL0:;
 }
 
 static void
-prod_91(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_92(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
-	case (TOK_EMPTY): case (TOK_NAME): case (TOK_CS__LITERAL): case (TOK_CHAR):
+	case (TOK_CHAR): case (TOK_EMPTY): case (TOK_NAME): case (TOK_CS__LITERAL):
 		{
 			map_term ZIt;
 
@@ -800,12 +813,12 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 619 "src/parser.act"
+#line 655 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 809 "src/bnf/parser.c"
+#line 822 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -822,44 +835,31 @@ ZL1:;
 }
 
 static void
-prod_92(lex_state lex_state, act_state act_state, map_term *ZOt)
+prod_93(lex_state lex_state, act_state act_state, map_term *ZOt)
 {
 	map_term ZIt;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CS__LITERAL):
 		{
-			map_string ZIs;
+			map_txt ZIx;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: CS_LITERAL */
 			{
-#line 477 "src/parser.act"
+#line 376 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIx.p = pattern_buffer(lex_state);
+		ZIx.n = strlen(ZIx.p);
 	
-#line 856 "src/bnf/parser.c"
+#line 855 "src/bnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: CS_LITERAL */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 563 "src/parser.act"
+#line 599 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term((ZIs), 0);
+		(ZIt) = ast_make_literal_term(&(ZIx), 0);
 	
 #line 865 "src/bnf/parser.c"
 			}
@@ -870,33 +870,19 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZOt)
 		{
 			map_string ZIs;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: NAME */
 			{
-#line 477 "src/parser.act"
+#line 367 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIs = pattern_buffer(lex_state);
 	
-#line 895 "src/bnf/parser.c"
+#line 880 "src/bnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: NAME */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 542 "src/parser.act"
+#line 578 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -914,7 +900,7 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 918 "src/bnf/parser.c"
+#line 904 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -934,7 +920,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 807 "src/parser.act"
+#line 843 "src/parser.act"
 
 
 	static int
@@ -1063,6 +1049,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1067 "src/bnf/parser.c"
+#line 1053 "src/bnf/parser.c"
 
 /* END OF FILE */

--- a/src/bnf/parser.h
+++ b/src/bnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 287 "src/parser.act"
+#line 315 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_bnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 809 "src/parser.act"
+#line 845 "src/parser.act"
 
 
 #line 31 "src/bnf/parser.h"

--- a/src/bnf/parser.sid
+++ b/src/bnf/parser.sid
@@ -12,6 +12,7 @@
 
 	char;
 	string;
+	txt;
 	count;
 
 	ast_rule;
@@ -41,14 +42,14 @@
 
 	EMPTY;
 	NAME:        () -> (:string);
-	!CI_LITERAL: () -> (:string);
-	CS_LITERAL:  () -> (:string);
+	!CI_LITERAL: () -> (:txt);
+	CS_LITERAL:  () -> (:txt);
 	!PROSE:      () -> (:string);
 
-	!BINSTR:   () -> (:string);
-	!OCTSTR:   () -> (:string);
-	!DECSTR:   () -> (:string);
-	!HEXSTR:   () -> (:string);
+	!BINSTR:   () -> (:txt);
+	!OCTSTR:   () -> (:txt);
+	!DECSTR:   () -> (:txt);
+	!HEXSTR:   () -> (:txt);
 
 	!BINRANGE: () -> (:char, :char);
 	!OCTRANGE: () -> (:char, :char);
@@ -68,8 +69,8 @@
 
 	<make-empty-term>:       ()             -> (:ast_term);
 	<make-rule-term>:        (:string)      -> (:ast_term);
-	!<make-ci-literal-term>: (:string)      -> (:ast_term);
-	<make-cs-literal-term>:  (:string)      -> (:ast_term);
+	!<make-ci-literal-term>: (:txt)         -> (:ast_term);
+	<make-cs-literal-term>:  (:txt)         -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
 	!<make-prose-term>:      (:string)      -> (:ast_term);
 	!<make-group-term>:      (:ast_alt)     -> (:ast_term);
@@ -109,8 +110,8 @@
 		t = <make-empty-term>;
 	||
 		body;
-		s = CS_LITERAL;
-		t = <make-cs-literal-term>(s);
+		x = CS_LITERAL;
+		t = <make-cs-literal-term>(x);
 	||
 		body;
 		s = NAME;

--- a/src/bnf/parser.sid
+++ b/src/bnf/parser.sid
@@ -34,16 +34,16 @@
 	!STARTOPT;   !ENDOPT;
 	!STARTSTAR;  !ENDSTAR;
 
-	EMPTY;
-	NAME;
-	!CI_LITERAL;
-	CS_LITERAL;
-	!PROSE;
-
 	!ESC:   () -> (:char);
 	CHAR:   () -> (:char);
 	!IDENT: () -> (:string);
 	!COUNT: () -> (:count);
+
+	EMPTY;
+	NAME:        () -> (:string);
+	!CI_LITERAL: () -> (:string);
+	CS_LITERAL:  () -> (:string);
+	!PROSE:      () -> (:string);
 
 	!BINSTR:   () -> (:string);
 	!OCTSTR:   () -> (:string);
@@ -58,7 +58,6 @@
 %productions%
 
 	<pattern-char>:   (:char) -> ();
-	<pattern-buffer>: ()      -> (:string);
 
 	!<rep-one-or-more>:  () -> (:count, :count);
 	!<rep-zero-or-more>: () -> (:count, :count);
@@ -110,13 +109,11 @@
 		t = <make-empty-term>;
 	||
 		body;
-		CS_LITERAL;
-		s = <pattern-buffer>;
+		s = CS_LITERAL;
 		t = <make-cs-literal-term>(s);
 	||
 		body;
-		NAME;
-		s = <pattern-buffer>;
+		s = NAME;
 		t = <make-rule-term>(s);
 	};
 
@@ -151,8 +148,7 @@
 
 	rule: () -> (r :ast_rule) = {
 		body;
-		NAME;
-		s = <pattern-buffer>;
+		s = NAME;
 
 		{
 			EQUALS;

--- a/src/dot/output.c
+++ b/src/dot/output.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "io.h"
@@ -60,6 +61,25 @@ escputs(const char *s, FILE *f)
 
 	for (p = s; *p != '\0'; p++) {
 		r = escputc(*p, f);
+		if (r < 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static int
+escputt(const struct txt *t, FILE *f)
+{
+	size_t i;
+	int r;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	for (i = 0; i < t->n; i++) {
+		r = escputc(t->p[i], f);
 		if (r < 0) {
 			return -1;
 		}
@@ -116,7 +136,7 @@ output_term(const struct ast_rule *grammar,
 	case TYPE_CI_LITERAL:
 	case TYPE_CS_LITERAL:
 		fputs("&quot;", stdout);
-		escputs(term->u.literal, stdout);
+		escputt(&term->u.literal, stdout);
 		fputs("&quot;", stdout);
 		if (term->type == TYPE_CI_LITERAL) {
 			fputs("/i", stdout);

--- a/src/html5/output.c
+++ b/src/html5/output.c
@@ -20,6 +20,7 @@
 #include <ctype.h>
 #include <math.h>
 
+#include "../txt.h"
 #include "../ast.h"
 #include "../xalloc.h"
 

--- a/src/iso-ebnf/io.h
+++ b/src/iso-ebnf/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define iso_ebnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_PROSE)
+#define iso_ebnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_PROSE | FEATURE_AST_BINARY)
 
 struct ast_rule *
 iso_ebnf_input(int (*f)(void *opaque), void *opaque);

--- a/src/iso-ebnf/output.c
+++ b/src/iso-ebnf/output.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "../txt.h"
 #include "../ast.h"
 #include "../rrd/node.h"
 
@@ -101,14 +102,14 @@ output_term(const struct ast_term *term)
 		exit(EXIT_FAILURE);
 
 	case TYPE_CS_LITERAL: {
-			const char *p;
+			size_t i;
 
 			fputs(" \"", stdout);
-			for (p = term->u.literal; *p != '\0'; p++) {
-				if (*p == '\"') {
+			for (i = 0; i < term->u.literal.n; i++) {
+				if (term->u.literal.p[i] == '\"') {
 					fputs("\"\"", stdout);
 				} else {
-					putc(*p, stdout);
+					putc(term->u.literal.p[i], stdout);
 				}
 			}
 			putc('\"', stdout);

--- a/src/iso-ebnf/parser.c
+++ b/src/iso-ebnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 99 "src/parser.act"
+#line 102 "src/parser.act"
 
 
 	#include <assert.h>
@@ -21,6 +21,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
 
@@ -55,6 +56,7 @@
 
 	typedef char         map_char;
 	typedef const char * map_string;
+	typedef struct txt   map_txt;
 	typedef unsigned int map_count;
 
 	typedef struct ast_term * map_term;
@@ -87,6 +89,27 @@
 	extern int allow_undefined;
 
 	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
+
+		assert(lex_state != NULL);
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+
+		return s;
+	}
+
+	static const char *
 	prefix(int base)
 	{
 		switch (base) {
@@ -99,10 +122,13 @@
 	}
 
 	static int
-	string(const char *p, char *q, int base)
+	string(const char *p, struct txt *t, int base)
 	{
+		char *q;
+
 		assert(p != NULL);
-		assert(q != NULL);
+		assert(t != NULL);
+		assert(t->p != NULL);
 		assert(base > 0);
 
 		{
@@ -116,6 +142,8 @@
 
 			p += z;
 		}
+
+		q = t->p;
 
 		for (;;) {
 			unsigned long n;
@@ -142,8 +170,7 @@
 			p = e + 1;
 		}
 
-		/* XXX: need to support \0 in strings */
-		*q = '\0';
+		t->n = q - t->p;
 
 		return 0;
 	}
@@ -259,7 +286,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 263 "src/iso-ebnf/parser.c"
+#line 290 "src/iso-ebnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -277,11 +304,11 @@ static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
 static void prod_repeatable_Hfactor(lex_state, act_state, map_term *);
-static void prod_94(lex_state, act_state, map_rule *);
-static void prod_95(lex_state, act_state, map_term *, map_alt *);
-static void prod_96(lex_state, act_state);
-static void prod_97(lex_state, act_state, map_term *);
+static void prod_95(lex_state, act_state, map_rule *);
+static void prod_96(lex_state, act_state, map_term *, map_alt *);
+static void prod_97(lex_state, act_state);
 static void prod_98(lex_state, act_state, map_term *);
+static void prod_99(lex_state, act_state, map_term *);
 static void prod_list_Hof_Hexcepts(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -313,11 +340,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 321 "src/iso-ebnf/parser.c"
+#line 348 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -342,33 +369,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 350 "src/iso-ebnf/parser.c"
+#line 377 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 498 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 360 "src/iso-ebnf/parser.c"
+#line 387 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 503 "src/parser.act"
+#line 539 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 372 "src/iso-ebnf/parser.c"
+#line 399 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -393,33 +420,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 401 "src/iso-ebnf/parser.c"
+#line 428 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 493 "src/parser.act"
+#line 529 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
 	
-#line 411 "src/iso-ebnf/parser.c"
+#line 438 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 503 "src/parser.act"
+#line 539 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 423 "src/iso-ebnf/parser.c"
+#line 450 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -470,21 +497,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 614 "src/parser.act"
+#line 650 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 478 "src/iso-ebnf/parser.c"
+#line 505 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 661 "src/parser.act"
+#line 697 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 488 "src/iso-ebnf/parser.c"
+#line 515 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -502,7 +529,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_repeatable_Hfactor (lex_state, act_state, &ZIl);
-		prod_97 (lex_state, act_state, &ZIl);
+		prod_98 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -526,7 +553,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_94 (lex_state, act_state, &ZIl);
+		prod_95 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -552,7 +579,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hexcepts (lex_state, act_state, &ZIt);
-		prod_95 (lex_state, act_state, &ZIt, &ZIl);
+		prod_96 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -582,13 +609,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 306 "src/parser.act"
+#line 340 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 592 "src/iso-ebnf/parser.c"
+#line 619 "src/iso-ebnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -601,12 +628,12 @@ ZL2_body:;
 			/* END OF INLINE: 73 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 465 "src/parser.act"
+#line 519 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 610 "src/iso-ebnf/parser.c"
+#line 637 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -637,7 +664,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 319 "src/parser.act"
+#line 353 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -654,13 +681,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 658 "src/iso-ebnf/parser.c"
+#line 685 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 542 "src/parser.act"
+#line 578 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -678,15 +705,15 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 682 "src/iso-ebnf/parser.c"
+#line 709 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
 		break;
-	case (TOK_CS__LITERAL): case (TOK_PROSE): case (TOK_CHAR):
+	case (TOK_CHAR): case (TOK_CS__LITERAL): case (TOK_PROSE):
 		{
 			prod_body (lex_state, act_state);
-			prod_98 (lex_state, act_state, &ZIt);
+			prod_99 (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -697,11 +724,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		{
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 530 "src/parser.act"
+#line 566 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term();
 	
-#line 705 "src/iso-ebnf/parser.c"
+#line 732 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -733,7 +760,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 319 "src/parser.act"
+#line 353 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -750,7 +777,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 754 "src/iso-ebnf/parser.c"
+#line 781 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -758,7 +785,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 89 */
+		/* BEGINNING OF INLINE: 90 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -774,17 +801,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 673 "src/parser.act"
+#line 709 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 782 "src/iso-ebnf/parser.c"
+#line 809 "src/iso-ebnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 89 */
+		/* END OF INLINE: 90 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -792,14 +819,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 610 "src/parser.act"
+#line 646 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 800 "src/iso-ebnf/parser.c"
+#line 827 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 90 */
+		/* BEGINNING OF INLINE: 91 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -815,17 +842,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 669 "src/parser.act"
+#line 705 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 823 "src/iso-ebnf/parser.c"
+#line 850 "src/iso-ebnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 90 */
+		/* END OF INLINE: 91 */
 	}
 	goto ZL0;
 ZL1:;
@@ -847,12 +874,12 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 327 "src/parser.act"
+#line 361 "src/parser.act"
 
 		ZIn = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 856 "src/iso-ebnf/parser.c"
+#line 883 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -870,7 +897,7 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: mul-repeat */
 			{
-#line 510 "src/parser.act"
+#line 546 "src/parser.act"
 
 		assert((ZIn) > 0);
 
@@ -889,7 +916,7 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(ZIt)->min *= (ZIn);
 		(ZIt)->max *= (ZIn);
 	
-#line 893 "src/iso-ebnf/parser.c"
+#line 920 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: mul-repeat */
 		}
@@ -915,7 +942,7 @@ ZL0:;
 }
 
 static void
-prod_94(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_95(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_IDENT):
@@ -929,7 +956,7 @@ prod_94(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 629 "src/parser.act"
+#line 665 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -941,7 +968,7 @@ prod_94(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 945 "src/iso-ebnf/parser.c"
+#line 972 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -958,7 +985,7 @@ ZL1:;
 }
 
 static void
-prod_95(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_96(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -967,7 +994,7 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 86 */
+			/* BEGINNING OF INLINE: 87 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -983,17 +1010,17 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 665 "src/parser.act"
+#line 701 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 991 "src/iso-ebnf/parser.c"
+#line 1018 "src/iso-ebnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 86 */
+			/* END OF INLINE: 87 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1001,21 +1028,21 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1009 "src/iso-ebnf/parser.c"
+#line 1036 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 624 "src/parser.act"
+#line 660 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1019 "src/iso-ebnf/parser.c"
+#line 1046 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1024,11 +1051,11 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1032 "src/iso-ebnf/parser.c"
+#line 1059 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1045,7 +1072,7 @@ ZL0:;
 }
 
 static void
-prod_96(lex_state lex_state, act_state act_state)
+prod_97(lex_state lex_state, act_state act_state)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_EXCEPT):
@@ -1060,11 +1087,11 @@ prod_96(lex_state lex_state, act_state act_state)
 			}
 			/* BEGINNING OF ACTION: err-unimplemented-except */
 			{
-#line 677 "src/parser.act"
+#line 713 "src/parser.act"
 
 		err_unimplemented(lex_state, "\"except\" productions");
 	
-#line 1068 "src/iso-ebnf/parser.c"
+#line 1095 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: err-unimplemented-except */
 		}
@@ -1081,7 +1108,7 @@ ZL1:;
 }
 
 static void
-prod_97(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_98(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CAT):
@@ -1096,12 +1123,12 @@ prod_97(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 619 "src/parser.act"
+#line 655 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1105 "src/iso-ebnf/parser.c"
+#line 1132 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1118,46 +1145,33 @@ ZL1:;
 }
 
 static void
-prod_98(lex_state lex_state, act_state act_state, map_term *ZOt)
+prod_99(lex_state lex_state, act_state act_state, map_term *ZOt)
 {
 	map_term ZIt;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CS__LITERAL):
 		{
-			map_string ZIs;
+			map_txt ZIx;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: CS_LITERAL */
 			{
-#line 477 "src/parser.act"
+#line 376 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIx.p = pattern_buffer(lex_state);
+		ZIx.n = strlen(ZIx.p);
 	
-#line 1152 "src/iso-ebnf/parser.c"
+#line 1165 "src/iso-ebnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: CS_LITERAL */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 563 "src/parser.act"
+#line 599 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term((ZIs), 0);
+		(ZIt) = ast_make_literal_term(&(ZIx), 0);
 	
-#line 1161 "src/iso-ebnf/parser.c"
+#line 1175 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -1166,33 +1180,19 @@ prod_98(lex_state lex_state, act_state act_state, map_term *ZOt)
 		{
 			map_string ZIs;
 
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
+			/* BEGINNING OF EXTRACT: PROSE */
 			{
-#line 477 "src/parser.act"
+#line 381 "src/parser.act"
 
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
+		ZIs = pattern_buffer(lex_state);
 	
-#line 1191 "src/iso-ebnf/parser.c"
+#line 1190 "src/iso-ebnf/parser.c"
 			}
-			/* END OF ACTION: pattern-buffer */
+			/* END OF EXTRACT: PROSE */
+			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-prose-term */
 			{
-#line 573 "src/parser.act"
+#line 609 "src/parser.act"
 
 		const char *s;
 
@@ -1230,7 +1230,7 @@ prod_list_Hof_Hexcepts(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIl);
-		prod_96 (lex_state, act_state);
+		prod_97 (lex_state, act_state);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1246,7 +1246,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 807 "src/parser.act"
+#line 843 "src/parser.act"
 
 
 	static int

--- a/src/iso-ebnf/parser.h
+++ b/src/iso-ebnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 287 "src/parser.act"
+#line 315 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_iso_Hebnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 809 "src/parser.act"
+#line 845 "src/parser.act"
 
 
 #line 31 "src/iso-ebnf/parser.h"

--- a/src/iso-ebnf/parser.sid
+++ b/src/iso-ebnf/parser.sid
@@ -18,6 +18,7 @@
 
 	char;
 	string;
+	txt;
 	count;
 
 	ast_rule;
@@ -51,14 +52,14 @@
 
 	!EMPTY;
 	!NAME:       () -> (:string);
-	!CI_LITERAL: () -> (:string);
-	CS_LITERAL:  () -> (:string);
+	!CI_LITERAL: () -> (:txt);
+	CS_LITERAL:  () -> (:txt);
 	PROSE:       () -> (:string);
 
-	!BINSTR:   () -> (:string);
-	!OCTSTR:   () -> (:string);
-	!DECSTR:   () -> (:string);
-	!HEXSTR:   () -> (:string);
+	!BINSTR:   () -> (:txt);
+	!OCTSTR:   () -> (:txt);
+	!DECSTR:   () -> (:txt);
+	!HEXSTR:   () -> (:txt);
 
 	!BINRANGE: () -> (:char, :char);
 	!OCTRANGE: () -> (:char, :char);
@@ -78,8 +79,8 @@
 
 	<make-empty-term>:       ()             -> (:ast_term);
 	<make-rule-term>:        (:string)      -> (:ast_term);
-	!<make-ci-literal-term>: (:string)      -> (:ast_term);
-	<make-cs-literal-term>:  (:string)      -> (:ast_term);
+	!<make-ci-literal-term>: (:txt)         -> (:ast_term);
+	<make-cs-literal-term>:  (:txt)         -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
 	<make-prose-term>:       (:string)      -> (:ast_term);
 	<make-group-term>:       (:ast_alt)     -> (:ast_term);
@@ -121,8 +122,8 @@
 		t = <make-empty-term>;
 	||
 		body;
-		s = CS_LITERAL;
-		t = <make-cs-literal-term>(s);
+		x = CS_LITERAL;
+		t = <make-cs-literal-term>(x);
 	||
 		body;
 		s = PROSE;

--- a/src/iso-ebnf/parser.sid
+++ b/src/iso-ebnf/parser.sid
@@ -44,16 +44,16 @@
 	STARTOPT;   ENDOPT;
 	STARTSTAR;  ENDSTAR;
 
-	!EMPTY;
-	!NAME;
-	!CI_LITERAL;
-	CS_LITERAL;
-	PROSE;
-
 	!ESC:  () -> (:char);
 	CHAR:  () -> (:char);
 	IDENT: () -> (:string);
 	COUNT: () -> (:count);
+
+	!EMPTY;
+	!NAME:       () -> (:string);
+	!CI_LITERAL: () -> (:string);
+	CS_LITERAL:  () -> (:string);
+	PROSE:       () -> (:string);
 
 	!BINSTR:   () -> (:string);
 	!OCTSTR:   () -> (:string);
@@ -68,7 +68,6 @@
 %productions%
 
 	<pattern-char>:   (:char) -> ();
-	<pattern-buffer>: ()      -> (:string);
 
 	!<rep-one-or-more>: () -> (:count, :count);
 	<rep-zero-or-more>: () -> (:count, :count);
@@ -122,13 +121,11 @@
 		t = <make-empty-term>;
 	||
 		body;
-		CS_LITERAL;
-		s = <pattern-buffer>;
+		s = CS_LITERAL;
 		t = <make-cs-literal-term>(s);
 	||
 		body;
-		PROSE;
-		s = <pattern-buffer>;
+		s = PROSE;
 		t = <make-prose-term>(s);
 	||
 		s = IDENT;

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "txt.h"
 #include "ast.h"
 #include "rewrite.h"
 #include "xalloc.h"

--- a/src/main.c
+++ b/src/main.c
@@ -57,9 +57,9 @@ struct io {
 	{ "rrdot",    NULL,           rrdot_output,    0, 0 },
 	{ "rrdump",   NULL,           rrdump_output,   0, 0 },
 	{ "rrtdump",  NULL,           rrtdump_output,  0, 0 },
-	{ "rrparcon", NULL,           rrparcon_output, 0, rrparcon_rrd_unsupported },
-	{ "rrll",     NULL,           rrll_output,     0, rrll_rrd_unsupported     },
-	{ "rrta",     NULL,           rrta_output,     0, rrta_rrd_unsupported     },
+	{ "rrparcon", NULL,           rrparcon_output, rrparcon_ast_unsupported, rrparcon_rrd_unsupported },
+	{ "rrll",     NULL,           rrll_output,     rrll_ast_unsupported, rrll_rrd_unsupported     },
+	{ "rrta",     NULL,           rrta_output,     rrta_ast_unsupported, rrta_rrd_unsupported     },
 	{ "rrtext",   NULL,           rrtext_output,   0, 0 },
 	{ "svg",      NULL,           svg_output,      0, 0 },
 	{ "html5",    NULL,           html5_output,    0, 0 },
@@ -184,6 +184,13 @@ main(int argc, char *argv[])
 			/* TODO: option to query if output is possible without rewriting */
 			switch (v & -v) {
 			case FEATURE_AST_CI_LITERAL: r = 1; rewrite_ci_literals(g); break;
+
+			case FEATURE_AST_BINARY:
+				if (ast_binary(g)) {
+					fprintf(stderr, "Binary strings not supported for this output language\n");
+					exit(EXIT_FAILURE);
+				}
+				break;
 			}
 
 			if (!r) {

--- a/src/parser.act
+++ b/src/parser.act
@@ -22,6 +22,7 @@
 
 	char   -> map_char;
 	string -> map_string;
+	txt    -> map_txt;
 	count  -> map_count;
 
 	ast_term -> map_term;
@@ -39,6 +40,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
 
@@ -73,6 +75,7 @@
 
 	typedef char         map_char;
 	typedef const char * map_string;
+	typedef struct txt   map_txt;
 	typedef unsigned int map_count;
 
 	typedef struct ast_term * map_term;
@@ -138,10 +141,13 @@
 	}
 
 	static int
-	string(const char *p, char *q, int base)
+	string(const char *p, struct txt *t, int base)
 	{
+		char *q;
+
 		assert(p != NULL);
-		assert(q != NULL);
+		assert(t != NULL);
+		assert(t->p != NULL);
 		assert(base > 0);
 
 		{
@@ -155,6 +161,8 @@
 
 			p += z;
 		}
+
+		q = t->p;
 
 		for (;;) {
 			unsigned long n;
@@ -181,8 +189,7 @@
 			p = e + 1;
 		}
 
-		/* XXX: need to support \0 in strings */
-		*q = '\0';
+		t->n = q - t->p;
 
 		return 0;
 	}
@@ -360,12 +367,14 @@
 		@s = pattern_buffer(lex_state);
 	@};
 
-	CI_LITERAL: () -> (s :string) = @{
-		@s = pattern_buffer(lex_state);
+	CI_LITERAL: () -> (t :txt) = @{
+		@t.p = pattern_buffer(lex_state);
+		@t.n = strlen(@t.p);
 	@};
 
-	CS_LITERAL: () -> (s :string) = @{
-		@s = pattern_buffer(lex_state);
+	CS_LITERAL: () -> (t :txt) = @{
+		@t.p = pattern_buffer(lex_state);
+		@t.n = strlen(@t.p);
 	@};
 
 	PROSE: () -> (s :string) = @{
@@ -373,14 +382,14 @@
 	@};
 
 
-	BINSTR: () -> (s :string) = @{
-		@s = xstrdup(lex_state->buf.a);
-		if (@s == NULL) {
+	BINSTR: () -> (t :txt) = @{
+		@t.p = xstrdup(lex_state->buf.a);
+		if (@t.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, @s,  2)) {
+		if (-1 == string(lex_state->buf.a, &@t,  2)) {
 			if (errno == ERANGE) {
 				err(lex_state, "binary sequence %s out of range: expected %s0..%s%s inclusive",
 					lex_state->buf.a, prefix(2), prefix(2), "11111111");
@@ -393,14 +402,14 @@
 		/* TODO: free */
 	@};
 
-	OCTSTR: () -> (s :string) = @{
-		@s = xstrdup(lex_state->buf.a);
-		if (@s == NULL) {
+	OCTSTR: () -> (t :txt) = @{
+		@t.p = xstrdup(lex_state->buf.a);
+		if (@t.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, @s,  8)) {
+		if (-1 == string(lex_state->buf.a, &@t,  8)) {
 			if (errno == ERANGE) {
 				err(lex_state, "octal sequence %s out of range: expected %s0..%s%o inclusive",
 					lex_state->buf.a, prefix(8), prefix(8), UCHAR_MAX);
@@ -413,14 +422,14 @@
 		/* TODO: free */
 	@};
 
-	DECSTR: () -> (s :string) = @{
-		@s = xstrdup(lex_state->buf.a);
-		if (@s == NULL) {
+	DECSTR: () -> (t :txt) = @{
+		@t.p = xstrdup(lex_state->buf.a);
+		if (@t.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, @s, 10)) {
+		if (-1 == string(lex_state->buf.a, &@t, 10)) {
 			if (errno == ERANGE) {
 				err(lex_state, "decimal sequence %s out of range: expected %s0..%s%u inclusive",
 					lex_state->buf.a, prefix(10), prefix(10), UCHAR_MAX);
@@ -433,14 +442,14 @@
 		/* TODO: free */
 	@};
 
-	HEXSTR: () -> (s :string) = @{
-		@s = xstrdup(lex_state->buf.a);
-		if (@s == NULL) {
+	HEXSTR: () -> (t :txt) = @{
+		@t.p = xstrdup(lex_state->buf.a);
+		if (@t.p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
 
-		if (-1 == string(lex_state->buf.a, @s, 16)) {
+		if (-1 == string(lex_state->buf.a, &@t, 16)) {
 			if (errno == ERANGE) {
 				err(lex_state, "hex sequence %s out of range: expected %s0..%s%x inclusive",
 					lex_state->buf.a, prefix(16), prefix(16), UCHAR_MAX);
@@ -575,19 +584,19 @@
 		@t = ast_make_rule_term(r);
 	@};
 
-	<make-ci-literal-term>: (l :string) -> (t :ast_term) = @{
-		char *p;
+	<make-ci-literal-term>: (x :txt) -> (t :ast_term) = @{
+		size_t i;
 
 		/* normalise case-insensitive strings for aesthetic reasons only */
-		for (p = @l; *p != '\0'; p++) {
-			*p = tolower((unsigned char) *p);
+		for (i = 0; i < @x.n; i++) {
+			((char *) @x.p)[i] = tolower((unsigned char) @x.p[i]);
 		}
 
-		@t = ast_make_literal_term(@l, 1);
+		@t = ast_make_literal_term(&@x, 1);
 	@};
 
-	<make-cs-literal-term>: (l :string) -> (t :ast_term) = @{
-		@t = ast_make_literal_term(@l, 0);
+	<make-cs-literal-term>: (x :txt) -> (t :ast_term) = @{
+		@t = ast_make_literal_term(&@x, 0);
 	@};
 
 	<make-token-term>: (n :string) -> (t :ast_term) = @{

--- a/src/parser.act
+++ b/src/parser.act
@@ -623,7 +623,7 @@
 
 		a = NULL;
 
-		for (i = @m; i <= @n; i++) {
+		for (i = (unsigned char) @m; i <= (unsigned char) @n; i++) {
 			struct ast_alt *new;
 			struct ast_term *t;
 

--- a/src/parser.act
+++ b/src/parser.act
@@ -105,6 +105,27 @@
 	extern int allow_undefined;
 
 	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
+
+		assert(lex_state != NULL);
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+
+		return s;
+	}
+
+	static const char *
 	prefix(int base)
 	{
 		switch (base) {
@@ -294,6 +315,12 @@
 
 %terminals%
 
+	/*
+	 * Note we strdup() here because the grammar permits adjacent patterns,
+	 * and so the pattern buffer will be overwritten by the LL(1) one-token
+	 * lookahead.
+	 */
+
 	ESC: () -> (c :char) = @{
 		assert(strlen(lex_state->buf.a) == 2);
 
@@ -327,6 +354,24 @@
 		@n = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	@};
+
+
+	NAME: () -> (s :string) = @{
+		@s = pattern_buffer(lex_state);
+	@};
+
+	CI_LITERAL: () -> (s :string) = @{
+		@s = pattern_buffer(lex_state);
+	@};
+
+	CS_LITERAL: () -> (s :string) = @{
+		@s = pattern_buffer(lex_state);
+	@};
+
+	PROSE: () -> (s :string) = @{
+		@s = pattern_buffer(lex_state);
+	@};
+
 
 	BINSTR: () -> (s :string) = @{
 		@s = xstrdup(lex_state->buf.a);
@@ -463,24 +508,6 @@
 	<pattern-char>: (c :char) -> () = @{
 		/* TODO */
 		*lex_state->p++ = @c;
-	@};
-
-	<pattern-buffer>: () -> (s :string) = @{
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		@s = xstrdup(lex_state->a);
-		if (@s == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
 	@};
 
 

--- a/src/rbnf/io.h
+++ b/src/rbnf/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define rbnf_ast_unsupported FEATURE_AST_CI_LITERAL
+#define rbnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
 
 struct ast_rule *
 rbnf_input(int (*f)(void *opaque), void *opaque);

--- a/src/rbnf/output.c
+++ b/src/rbnf/output.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "io.h"

--- a/src/rbnf/parser.h
+++ b/src/rbnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 287 "src/parser.act"
+#line 315 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_rbnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 809 "src/parser.act"
+#line 845 "src/parser.act"
 
 
 #line 31 "src/rbnf/parser.h"

--- a/src/rbnf/parser.sid
+++ b/src/rbnf/parser.sid
@@ -12,6 +12,7 @@
 
 	char;
 	string;
+	txt;
 	count;
 
 	ast_rule;
@@ -41,14 +42,14 @@
 
 	!EMPTY;
 	NAME:        () -> (:string);
-	!CI_LITERAL: () -> (:string);
-	!CS_LITERAL: () -> (:string);
+	!CI_LITERAL: () -> (:txt);
+	!CS_LITERAL: () -> (:txt);
 	!PROSE:      () -> (:string);
 
-	!BINSTR:   () -> (:string);
-	!OCTSTR:   () -> (:string);
-	!DECSTR:   () -> (:string);
-	!HEXSTR:   () -> (:string);
+	!BINSTR:   () -> (:txt);
+	!OCTSTR:   () -> (:txt);
+	!DECSTR:   () -> (:txt);
+	!HEXSTR:   () -> (:txt);
 
 	!BINRANGE: () -> (:char, :char);
 	!OCTRANGE: () -> (:char, :char);
@@ -68,8 +69,8 @@
 
 	!<make-empty-term>:      ()             -> (:ast_term);
 	<make-rule-term>:        (:string)      -> (:ast_term);
-	!<make-ci-literal-term>: (:string)      -> (:ast_term);
-	!<make-cs-literal-term>: (:string)      -> (:ast_term);
+	!<make-ci-literal-term>: (:txt)         -> (:ast_term);
+	!<make-cs-literal-term>: (:txt)         -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
 	!<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:       (:ast_alt)     -> (:ast_term);

--- a/src/rbnf/parser.sid
+++ b/src/rbnf/parser.sid
@@ -34,16 +34,16 @@
 	STARTOPT;   ENDOPT;
 	!STARTSTAR; !ENDSTAR;
 
-	!EMPTY;
-	NAME;
-	!CI_LITERAL;
-	!CS_LITERAL;
-	!PROSE;
-
 	!ESC:   () -> (:char);
 	CHAR:   () -> (:char);
 	!IDENT: () -> (:string);
 	!COUNT: () -> (:count);
+
+	!EMPTY;
+	NAME:        () -> (:string);
+	!CI_LITERAL: () -> (:string);
+	!CS_LITERAL: () -> (:string);
+	!PROSE:      () -> (:string);
 
 	!BINSTR:   () -> (:string);
 	!OCTSTR:   () -> (:string);
@@ -58,7 +58,6 @@
 %productions%
 
 	<pattern-char>:   (:char) -> ();
-	<pattern-buffer>: ()      -> (:string);
 
 	!<rep-one-or-more>: () -> (:count, :count);
 	<rep-zero-or-more>: () -> (:count, :count);
@@ -109,8 +108,7 @@
 
 	term: () -> (t :ast_term) = {
 		body;
-		NAME;
-		s = <pattern-buffer>;
+		s = NAME;
 		t = <make-rule-term>(s);
 	};
 
@@ -165,8 +163,7 @@
 
 	rule: () -> (r :ast_rule) = {
 		body;
-		NAME;
-		s = <pattern-buffer>;
+		s = NAME;
 
 		{
 			EQUALS;

--- a/src/rrd/list.c
+++ b/src/rrd/list.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "list.h"

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -9,6 +9,8 @@
 #include <strings.h>
 #include <stdlib.h>
 
+#include "../txt.h"
+
 #include "list.h"
 #include "node.h"
 
@@ -26,6 +28,9 @@ node_free(struct node *n)
 	switch (n->type) {
 	case NODE_CI_LITERAL:
 	case NODE_CS_LITERAL:
+		/* TODO: free (struct txt).p? */
+		break;
+
 	case NODE_RULE:
 		break;
 
@@ -54,7 +59,7 @@ node_free(struct node *n)
 }
 
 struct node *
-node_create_ci_literal(const char *literal)
+node_create_ci_literal(const struct txt *literal)
 {
 	struct node *new;
 
@@ -64,13 +69,13 @@ node_create_ci_literal(const char *literal)
 
 	new->type = NODE_CI_LITERAL;
 
-	new->u.literal = literal;
+	new->u.literal = *literal;
 
 	return new;
 }
 
 struct node *
-node_create_cs_literal(const char *literal)
+node_create_cs_literal(const struct txt *literal)
 {
 	struct node *new;
 
@@ -80,7 +85,7 @@ node_create_cs_literal(const char *literal)
 
 	new->type = NODE_CS_LITERAL;
 
-	new->u.literal = literal;
+	new->u.literal = *literal;
 
 	return new;
 }
@@ -212,10 +217,10 @@ node_compare(const struct node *a, const struct node *b)
 
 	switch (a->type) {
 	case NODE_CI_LITERAL:
-		return 0 == strcasecmp(a->u.literal, b->u.literal);
+		return 0 == txtcasecmp(&a->u.literal, &b->u.literal);
 
 	case NODE_CS_LITERAL:
-		return 0 == strcmp(a->u.literal, b->u.literal);
+		return 0 == txtcmp(&a->u.literal, &b->u.literal);
 
 	case NODE_RULE:
 		return 0 == strcmp(a->u.name, b->u.name);

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -24,8 +24,8 @@ struct node {
 	} type;
 
 	union {
-		const char *literal; /* TODO: point to ast_literal instead */
-		const char *name;    /* TODO: point to ast_rule instead */
+		struct txt literal; /* TODO: point to ast_literal instead */
+		const char *name;   /* TODO: point to ast_rule instead */
 		const char *prose;
 
 		struct list *alt;
@@ -44,10 +44,10 @@ void
 node_free(struct node *);
 
 struct node *
-node_create_ci_literal(const char *literal);
+node_create_ci_literal(const struct txt *literal);
 
 struct node *
-node_create_cs_literal(const char *literal);
+node_create_cs_literal(const struct txt *literal);
 
 struct node *
 node_create_name(const char *name);

--- a/src/rrd/pretty.c
+++ b/src/rrd/pretty.c
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <assert.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "node.h"

--- a/src/rrd/pretty_affix.c
+++ b/src/rrd/pretty_affix.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "pretty.h"

--- a/src/rrd/pretty_bottom.c
+++ b/src/rrd/pretty_bottom.c
@@ -8,6 +8,8 @@
 #include <stddef.h>
 #include <assert.h>
 
+#include "../txt.h"
+
 #include "pretty.h"
 #include "node.h"
 #include "list.h"

--- a/src/rrd/pretty_ci.c
+++ b/src/rrd/pretty_ci.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "pretty.h"
@@ -41,7 +42,7 @@ ci_alt(int *changed, struct node *n)
 		switch (p->node->type) {
 		case NODE_CI_LITERAL:
 		case NODE_CS_LITERAL:
-			if (strlen(p->node->u.literal) != 1) {
+			if (p->node->u.literal.n != 1) {
 				return;
 			}
 
@@ -56,19 +57,19 @@ ci_alt(int *changed, struct node *n)
 
 		switch (p->node->type) {
 			struct node *new;
-			char *s;
+			struct txt t;
 
 		case NODE_CI_LITERAL:
-			if (!isalpha((unsigned char) *p->node->u.literal)) {
+			if (!isalpha((unsigned char) *p->node->u.literal.p)) {
 				break;
 			}
 
 			p->node->type = NODE_CS_LITERAL;
-			* (char *) p->node->u.literal = tolower((unsigned char) *p->node->u.literal);
+			* (char *) p->node->u.literal.p = tolower((unsigned char) *p->node->u.literal.p);
 
-			s = xstrdup(p->node->u.literal);
-			*s = toupper((unsigned char) *s);
-			new = node_create_cs_literal(s);
+			t = xtxtdup(&p->node->u.literal);
+			* (char *) t.p = toupper((unsigned char) *t.p);
+			new = node_create_cs_literal(&t);
 			list_push(&list, new);
 
 			*changed = 1;

--- a/src/rrd/pretty_collapse.c
+++ b/src/rrd/pretty_collapse.c
@@ -7,6 +7,8 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "../txt.h"
+
 #include "pretty.h"
 #include "node.h"
 #include "list.h"

--- a/src/rrd/pretty_nested.c
+++ b/src/rrd/pretty_nested.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "pretty.h"

--- a/src/rrd/pretty_redundant.c
+++ b/src/rrd/pretty_redundant.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "pretty.h"

--- a/src/rrd/pretty_roll.c
+++ b/src/rrd/pretty_roll.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "pretty.h"

--- a/src/rrd/pretty_skippable.c
+++ b/src/rrd/pretty_skippable.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "../txt.h"
 #include "../xalloc.h"
 
 #include "pretty.h"

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 #include "../bitmap.h"
 #include "../xalloc.h"
@@ -97,7 +98,7 @@ tnode_free(struct tnode *n)
 
 	case TNODE_CI_LITERAL:
 	case TNODE_CS_LITERAL:
-		free((void *) n->u.literal);
+		free((void *) n->u.literal.p);
 		break;
 
 	case TNODE_PROSE:
@@ -135,11 +136,11 @@ char_terminal(const struct node *node, unsigned char *c)
 		return 0;
 	}
 
-	if (strlen(node->u.literal) != 1) {
+	if (node->u.literal.n != 1) {
 		return 0;
 	}
 
-	*c = (unsigned) node->u.literal[0];
+	*c = (unsigned) node->u.literal.p[0];
 
 	return 1;
 }
@@ -467,15 +468,15 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 	switch (node->type) {
 	case NODE_CI_LITERAL:
 		new->type = TNODE_CI_LITERAL;
-		new->u.literal = xstrdup(node->u.literal);
-		dim->literal_string(new->u.literal, &new->w, &new->a, &new->d);
+		new->u.literal = xtxtdup(&node->u.literal);
+		dim->literal_txt(&new->u.literal, &new->w, &new->a, &new->d);
 		new->w += dim->literal_padding + dim->ci_marker;
 		break;
 
 	case NODE_CS_LITERAL:
 		new->type = TNODE_CS_LITERAL;
-		new->u.literal = xstrdup(node->u.literal);
-		dim->literal_string(new->u.literal, &new->w, &new->a, &new->d);
+		new->u.literal = xtxtdup(&node->u.literal);
+		dim->literal_txt(&new->u.literal, &new->w, &new->a, &new->d);
 		new->w += dim->literal_padding;
 		break;
 

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -231,13 +231,11 @@ tnode_create_alt_list(const struct list *list, int rtl, const struct dim *dim)
 		lo = bm_next(&bm, hi, 1);
 		if (lo > UCHAR_MAX) {
 			/* end of list */
+			break;
 		}
 
 		/* end of range */
 		hi = bm_next(&bm, lo, 0);
-		if (hi > UCHAR_MAX && lo < UCHAR_MAX) {
-			hi = UCHAR_MAX;
-		}
 
 		if (!isalnum((unsigned char) lo) && isalnum((unsigned char) hi)) {
 			new.a[i++] = tnode_create_node(find_node(list, lo), rtl, dim);

--- a/src/rrd/tnode.h
+++ b/src/rrd/tnode.h
@@ -8,6 +8,7 @@
 #define KGT_RRD_TNODE_H
 
 struct node;
+struct txt;
 
 /*
  * Various combinations of two endpoints (corner pieces) for a line:
@@ -77,8 +78,8 @@ struct tnode {
 	unsigned d; /* descender - depth below the line */
 
 	union {
-		const char *literal; /* TODO: point to ast_literal instead */
-		const char *name;    /* TODO: point to ast_rule instead */
+		struct txt literal; /* TODO: point to ast_literal instead */
+		const char *name;   /* TODO: point to ast_rule instead */
 		const char *prose;
 
 		struct {
@@ -92,8 +93,8 @@ struct tnode {
 };
 
 struct dim {
-	void (*literal_string)(const char *s, unsigned *w, unsigned *a, unsigned *d);
-	void (*rule_string   )(const char *s, unsigned *w, unsigned *a, unsigned *d);
+	void (*literal_txt)(const struct txt *t, unsigned *w, unsigned *a, unsigned *d);
+	void (*rule_string)(const char *s, unsigned *w, unsigned *a, unsigned *d);
 	unsigned literal_padding;
 	unsigned rule_padding;
 	unsigned prose_padding;

--- a/src/rrd/transform.c
+++ b/src/rrd/transform.c
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <errno.h>
 
+#include "../txt.h"
 #include "../ast.h"
 #include "../xalloc.h"
 
@@ -105,11 +106,11 @@ single_term(const struct ast_term *term, struct node **r)
 
 	case TYPE_CI_LITERAL:
 		/* can't create a sequence of alts; the tokenisation would be wrong */
-		*r = node_create_ci_literal(term->u.literal);
+		*r = node_create_ci_literal(&term->u.literal);
 		return 1;
 
 	case TYPE_CS_LITERAL:
-		*r = node_create_cs_literal(term->u.literal);
+		*r = node_create_cs_literal(&term->u.literal);
 		return 1;
 
 	case TYPE_TOKEN:

--- a/src/rrdot/output.c
+++ b/src/rrdot/output.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "../rrd/rrd.h"
@@ -72,6 +73,25 @@ escputs(const char *s, FILE *f)
 	return 0;
 }
 
+static int
+escputt(const struct txt *t, FILE *f)
+{
+	size_t i;
+	int r;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	for (i = 0; i < t->n; i++) {
+		r = escputc(t->p[i], f);
+		if (r < 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 static void
 rrd_print_dot(const char *prefix, const void *parent, const char *port,
 	const struct node *node)
@@ -114,13 +134,13 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 	switch (node->type) {
 	case NODE_CI_LITERAL:
 		printf("style = filled, shape = box, label = \"\\\"");
-		escputs(node->u.literal, stdout);
+		escputt(&node->u.literal, stdout);
 		printf("\\\"\"/i");
 		break;
 
 	case NODE_CS_LITERAL:
 		printf("style = filled, shape = box, label = \"\\\"");
-		escputs(node->u.literal, stdout);
+		escputt(&node->u.literal, stdout);
 		printf("\\\"\"");
 		break;
 

--- a/src/rrdump/output.c
+++ b/src/rrdump/output.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "../rrd/rrd.h"

--- a/src/rrll/io.h
+++ b/src/rrll/io.h
@@ -9,6 +9,7 @@
 
 struct ast_rule;
 
+#define rrll_ast_unsupported FEATURE_AST_BINARY
 #define rrll_rrd_unsupported FEATURE_RRD_CI_LITERAL
 
 extern int prettify;

--- a/src/rrll/output.c
+++ b/src/rrll/output.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "../rrd/rrd.h"
@@ -87,6 +88,26 @@ escputs(const char *s, FILE *f)
 }
 
 /* TODO: centralise */
+static int
+escputt(const struct txt *t, FILE *f)
+{
+	size_t i;
+	int r;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	for (i = 0; i < t->n; i++) {
+		r = escputc(t->p[i], f);
+		if (r < 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+/* TODO: centralise */
 static size_t
 loop_label(unsigned min, unsigned max, char *s)
 {
@@ -130,7 +151,7 @@ node_walk(FILE *f, const struct node *n)
 
 	case NODE_CS_LITERAL:
 		fprintf(f, "\"");
-		escputs(n->u.literal, f);
+		escputt(&n->u.literal, f);
 		fprintf(f, "\"");
 
 		break;

--- a/src/rrparcon/io.h
+++ b/src/rrparcon/io.h
@@ -9,6 +9,7 @@
 
 struct ast_rule;
 
+#define rrparcon_ast_unsupported FEATURE_AST_BINARY
 #define rrparcon_rrd_unsupported FEATURE_RRD_CI_LITERAL
 
 extern int prettify;

--- a/src/rrparcon/output.c
+++ b/src/rrparcon/output.c
@@ -19,6 +19,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "../rrd/rrd.h"
@@ -102,6 +103,26 @@ escputs(const char *s, FILE *f)
 	return n;
 }
 
+/* TODO: centralise */
+static int
+escputt(const struct txt *t, FILE *f)
+{
+	size_t i;
+	int r;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	for (i = 0; i < t->n; i++) {
+		r = escputc(t->p[i], f);
+		if (r < 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 static void
 print_comment(FILE *f, int depth, const char *fmt, ...)
 {
@@ -142,7 +163,7 @@ node_walk(FILE *f, const struct node *n, int depth)
 	case NODE_CS_LITERAL:
 		print_indent(f, depth);
 		fprintf(f, "text(\"");
-		escputs(n->u.literal, f);
+		escputt(&n->u.literal, f);
 		fprintf(f, "\")");
 
 		break;

--- a/src/rrta/io.h
+++ b/src/rrta/io.h
@@ -9,6 +9,7 @@
 
 struct ast_rule;
 
+#define rrta_ast_unsupported FEATURE_AST_BINARY
 #define rrta_rrd_unsupported FEATURE_RRD_CI_LITERAL
 
 extern int prettify;

--- a/src/rrta/output.c
+++ b/src/rrta/output.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "../rrd/rrd.h"
@@ -97,6 +98,26 @@ escputs(const char *s, FILE *f)
 	return n;
 }
 
+/* TODO: centralise */
+static int
+escputt(const struct txt *t, FILE *f)
+{
+	size_t i;
+	int r;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	for (i = 0; i < t->n; i++) {
+		r = escputc(t->p[i], f);
+		if (r < 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 int
 normal(const struct list *list)
 {
@@ -143,7 +164,7 @@ node_walk(FILE *f, const struct node *n, int depth)
 	case NODE_CS_LITERAL:
 		print_indent(f, depth);
 		fprintf(f, "Terminal(\"");
-		escputs(n->u.literal, f);
+		escputt(&n->u.literal, f);
 		fprintf(f, "\")");
 
 		break;

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -87,7 +87,7 @@ tnode_walk(FILE *f, const struct tnode *n, int depth)
 		print_indent(f, depth);
 		fprintf(f, "LITERAL");
 		print_coords(f, n);
-		fprintf(f, ": \"%s\"%s\n", n->u.literal,
+		fprintf(f, ": \"%.*s\"%s\n", (int) n->u.literal.n, n->u.literal.p,
 			n->type == TNODE_CI_LITERAL ? "/i" : "");
 
 		break;

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "../rrd/rrd.h"

--- a/src/sid/io.h
+++ b/src/sid/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define sid_ast_unsupported FEATURE_AST_CI_LITERAL
+#define sid_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
 
 void
 sid_output(const struct ast_rule *grammar);

--- a/src/sid/output.c
+++ b/src/sid/output.c
@@ -15,7 +15,9 @@
 #include <string.h>
 #include <strings.h>
 #include <assert.h>
+#include <ctype.h>
 
+#include "../txt.h"
 #include "../ast.h"
 #include "../xalloc.h"
 
@@ -30,14 +32,15 @@ output_section(const char *section)
 }
 
 static void
-output_literal(const char *s)
+output_literal(const struct txt *t)
 {
 	char c;
 
-	assert(s != NULL);
+	assert(t != NULL);
+	assert(t->p != NULL);
 
-	c = strchr(s, '\"') ? '\'' : '\"';
-	printf("%c%s%c; ", c, s, c);
+	c = memchr(t->p, '\"', t->n) ? '\'' : '\"';
+	printf("%c%.*s%c; ", c, (int) t->n, t->p, c);
 }
 
 static void
@@ -57,7 +60,7 @@ output_basic(const struct ast_term *term)
 		exit(EXIT_FAILURE);
 
 	case TYPE_CS_LITERAL:
-		output_literal(term->u.literal);
+		output_literal(&term->u.literal);
 		break;
 
 	case TYPE_TOKEN:
@@ -132,11 +135,11 @@ is_equal(const struct ast_term *a, const struct ast_term *b)
 	}
 
 	switch (a->type) {
-	case TYPE_RULE:       return 0 == strcmp(a->u.rule->name,  b->u.rule->name);
-	case TYPE_CI_LITERAL: return 0 == strcasecmp(a->u.literal, b->u.literal);
-	case TYPE_CS_LITERAL: return 0 == strcmp(a->u.literal,     b->u.literal);
-	case TYPE_TOKEN:      return 0 == strcmp(a->u.token,       b->u.token);
-	case TYPE_PROSE:      return 0 == strcmp(a->u.prose,       b->u.prose);
+	case TYPE_RULE:       return 0 == strcmp(a->u.rule->name,    b->u.rule->name);
+	case TYPE_CI_LITERAL: return 0 == txtcasecmp(&a->u.literal, &b->u.literal);
+	case TYPE_CS_LITERAL: return 0 == txtcmp(&a->u.literal,     &b->u.literal);
+	case TYPE_TOKEN:      return 0 == strcmp(a->u.token,         b->u.token);
+	case TYPE_PROSE:      return 0 == strcmp(a->u.prose,         b->u.prose);
 	}
 }
 

--- a/src/txt.c
+++ b/src/txt.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <ctype.h>
+
+#include "txt.h"
+
+int
+txtcasecmp(const struct txt *t1, const struct txt *t2)
+{
+	size_t i;
+
+	assert(t1 != NULL);
+	assert(t2 != NULL);
+
+	if (t1->n < t2->n) {
+		return -1;
+	}
+
+	if (t1->n > t2->n) {
+		return +1;
+	}
+
+	for (i = 0; i < t1->n; i++) {
+		if (tolower((unsigned char) t1->p[i]) != tolower((unsigned char) t2->p[i])) {
+			return (int) (unsigned char) t1->p[i] - (int) (unsigned char) t2->p[i];
+		}
+	}
+
+	return 0;
+}
+
+int
+txtcmp(const struct txt *t1, const struct txt *t2)
+{
+	size_t i;
+
+	assert(t1 != NULL);
+	assert(t2 != NULL);
+
+	if (t1->n < t2->n) {
+		return -1;
+	}
+
+	if (t1->n > t2->n) {
+		return +1;
+	}
+
+	for (i = 0; i < t1->n; i++) {
+		if (t1->p[i] != t2->p[i]) {
+			return (int) (unsigned char) t1->p[i] - (int) (unsigned char) t2->p[i];
+		}
+	}
+
+	return 0;
+}
+

--- a/src/txt.h
+++ b/src/txt.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef KGT_TXT_H
+#define KGT_TXT_H
+
+struct txt {
+	const char *p;
+	size_t n;
+};
+
+int
+txtcasecmp(const struct txt *t1, const struct txt *t2);
+
+int
+txtcmp(const struct txt *t1, const struct txt *t2);
+
+#endif
+

--- a/src/wsn/io.h
+++ b/src/wsn/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define wsn_ast_unsupported FEATURE_AST_CI_LITERAL
+#define wsn_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
 
 struct ast_rule *
 wsn_input(int (*f)(void *opaque), void *opaque);

--- a/src/wsn/output.c
+++ b/src/wsn/output.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "../txt.h"
 #include "../ast.h"
 
 #include "io.h"
@@ -78,14 +79,14 @@ output_term(const struct ast_term *term)
 		exit(EXIT_FAILURE);
 
 	case TYPE_CS_LITERAL: {
-			const char *p;
+			size_t i;
 
 			fputs(" \"", stdout);
-			for (p = term->u.literal; *p != '\0'; p++) {
-				if (*p == '\"') {
+			for (i = 0; i < term->u.literal.n; i++) {
+				if (term->u.literal.p[i] == '\"') {
 					fputs("\"\"", stdout);
 				} else {
-					putc(*p, stdout);
+					putc(term->u.literal.p[i], stdout);
 				}
 			}
 			putc('\"', stdout);

--- a/src/wsn/parser.c
+++ b/src/wsn/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 99 "src/parser.act"
+#line 102 "src/parser.act"
 
 
 	#include <assert.h>
@@ -21,6 +21,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
 
@@ -55,6 +56,7 @@
 
 	typedef char         map_char;
 	typedef const char * map_string;
+	typedef struct txt   map_txt;
 	typedef unsigned int map_count;
 
 	typedef struct ast_term * map_term;
@@ -87,6 +89,27 @@
 	extern int allow_undefined;
 
 	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
+
+		assert(lex_state != NULL);
+
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+
+		return s;
+	}
+
+	static const char *
 	prefix(int base)
 	{
 		switch (base) {
@@ -99,10 +122,13 @@
 	}
 
 	static int
-	string(const char *p, char *q, int base)
+	string(const char *p, struct txt *t, int base)
 	{
+		char *q;
+
 		assert(p != NULL);
-		assert(q != NULL);
+		assert(t != NULL);
+		assert(t->p != NULL);
 		assert(base > 0);
 
 		{
@@ -116,6 +142,8 @@
 
 			p += z;
 		}
+
+		q = t->p;
 
 		for (;;) {
 			unsigned long n;
@@ -142,8 +170,7 @@
 			p = e + 1;
 		}
 
-		/* XXX: need to support \0 in strings */
-		*q = '\0';
+		t->n = q - t->p;
 
 		return 0;
 	}
@@ -259,7 +286,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 263 "src/wsn/parser.c"
+#line 290 "src/wsn/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -276,9 +303,9 @@ static void prod_body(lex_state, act_state);
 static void prod_term(lex_state, act_state, map_term *);
 static void prod_rule(lex_state, act_state, map_rule *);
 extern void prod_wsn(lex_state, act_state, map_rule *);
-static void prod_92(lex_state, act_state, map_rule *);
-static void prod_93(lex_state, act_state, map_term *, map_alt *);
-static void prod_94(lex_state, act_state, map_term *);
+static void prod_93(lex_state, act_state, map_rule *);
+static void prod_94(lex_state, act_state, map_term *, map_alt *);
+static void prod_95(lex_state, act_state, map_term *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -309,11 +336,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 317 "src/wsn/parser.c"
+#line 344 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -338,33 +365,33 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 346 "src/wsn/parser.c"
+#line 373 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 498 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
 	
-#line 356 "src/wsn/parser.c"
+#line 383 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 503 "src/parser.act"
+#line 539 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 368 "src/wsn/parser.c"
+#line 395 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -389,39 +416,39 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 581 "src/parser.act"
+#line 617 "src/parser.act"
 
 		(ZIt) = ast_make_group_term((ZIa));
 	
-#line 397 "src/wsn/parser.c"
+#line 424 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 493 "src/parser.act"
+#line 529 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
 	
-#line 407 "src/wsn/parser.c"
+#line 434 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 503 "src/parser.act"
+#line 539 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 419 "src/wsn/parser.c"
+#line 446 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
 		break;
-	case (TOK_EMPTY): case (TOK_CS__LITERAL): case (TOK_ESC): case (TOK_CHAR):
-	case (TOK_IDENT):
+	case (TOK_ESC): case (TOK_CHAR): case (TOK_IDENT): case (TOK_EMPTY):
+	case (TOK_CS__LITERAL):
 		{
 			prod_term (lex_state, act_state, &ZIt);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
@@ -453,7 +480,7 @@ prod_list_Hof_Hterms(lex_state lex_state, act_state act_state, map_term *ZOl)
 	}
 	{
 		prod_factor (lex_state, act_state, &ZIl);
-		prod_94 (lex_state, act_state, &ZIl);
+		prod_95 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -477,7 +504,7 @@ prod_list_Hof_Hrules(lex_state lex_state, act_state act_state, map_rule *ZOl)
 	}
 	{
 		prod_rule (lex_state, act_state, &ZIl);
-		prod_92 (lex_state, act_state, &ZIl);
+		prod_93 (lex_state, act_state, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -503,7 +530,7 @@ prod_list_Hof_Halts(lex_state lex_state, act_state act_state, map_alt *ZOl)
 		map_term ZIt;
 
 		prod_list_Hof_Hterms (lex_state, act_state, &ZIt);
-		prod_93 (lex_state, act_state, &ZIt, &ZIl);
+		prod_94 (lex_state, act_state, &ZIt, &ZIl);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -533,13 +560,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 306 "src/parser.act"
+#line 340 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 543 "src/wsn/parser.c"
+#line 570 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -549,13 +576,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: ESC */
 						{
-#line 300 "src/parser.act"
+#line 334 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 2);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 559 "src/wsn/parser.c"
+#line 586 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -568,12 +595,12 @@ ZL2_body:;
 			/* END OF INLINE: 73 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 465 "src/parser.act"
+#line 519 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 577 "src/wsn/parser.c"
+#line 604 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -603,11 +630,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 530 "src/parser.act"
+#line 566 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term();
 	
-#line 611 "src/wsn/parser.c"
+#line 638 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -618,7 +645,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 319 "src/parser.act"
+#line 353 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -635,13 +662,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 639 "src/wsn/parser.c"
+#line 666 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 542 "src/parser.act"
+#line 578 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -659,18 +686,28 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(r);
 	
-#line 663 "src/wsn/parser.c"
+#line 690 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
 		break;
-	case (TOK_CS__LITERAL): case (TOK_ESC): case (TOK_CHAR):
+	case (TOK_ESC): case (TOK_CHAR): case (TOK_CS__LITERAL):
 		{
-			map_string ZIs;
+			map_txt ZIx;
 
 			prod_body (lex_state, act_state);
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CS__LITERAL):
+				/* BEGINNING OF EXTRACT: CS_LITERAL */
+				{
+#line 376 "src/parser.act"
+
+		ZIx.p = pattern_buffer(lex_state);
+		ZIx.n = strlen(ZIx.p);
+	
+#line 709 "src/wsn/parser.c"
+				}
+				/* END OF EXTRACT: CS_LITERAL */
 				break;
 			case (ERROR_TERMINAL):
 				RESTORE_LEXER;
@@ -679,36 +716,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: pattern-buffer */
-			{
-#line 477 "src/parser.act"
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
-		 * lookahead.
-		 */
-		(ZIs) = xstrdup(lex_state->a);
-		if ((ZIs) == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-	
-#line 703 "src/wsn/parser.c"
-			}
-			/* END OF ACTION: pattern-buffer */
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 563 "src/parser.act"
+#line 599 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term((ZIs), 0);
+		(ZIt) = ast_make_literal_term(&(ZIx), 0);
 	
-#line 712 "src/wsn/parser.c"
+#line 726 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -742,7 +756,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 319 "src/parser.act"
+#line 353 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -759,7 +773,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 763 "src/wsn/parser.c"
+#line 777 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -767,7 +781,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 86 */
+		/* BEGINNING OF INLINE: 87 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -783,17 +797,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 673 "src/parser.act"
+#line 709 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 791 "src/wsn/parser.c"
+#line 805 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 86 */
+		/* END OF INLINE: 87 */
 		prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
@@ -801,14 +815,14 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 610 "src/parser.act"
+#line 646 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 809 "src/wsn/parser.c"
+#line 823 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-rule */
-		/* BEGINNING OF INLINE: 87 */
+		/* BEGINNING OF INLINE: 88 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -824,17 +838,17 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 669 "src/parser.act"
+#line 705 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 832 "src/wsn/parser.c"
+#line 846 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 87 */
+		/* END OF INLINE: 88 */
 	}
 	goto ZL0;
 ZL1:;
@@ -870,21 +884,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 614 "src/parser.act"
+#line 650 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 878 "src/wsn/parser.c"
+#line 892 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 661 "src/parser.act"
+#line 697 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 888 "src/wsn/parser.c"
+#line 902 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -893,7 +907,7 @@ ZL0:;
 }
 
 static void
-prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
+prod_93(lex_state lex_state, act_state act_state, map_rule *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_IDENT):
@@ -907,7 +921,7 @@ prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 629 "src/parser.act"
+#line 665 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -919,7 +933,7 @@ prod_92(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 923 "src/wsn/parser.c"
+#line 937 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -936,7 +950,7 @@ ZL1:;
 }
 
 static void
-prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
+prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 {
 	map_alt ZIl;
 
@@ -945,7 +959,7 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			map_alt ZIa;
 
-			/* BEGINNING OF INLINE: 83 */
+			/* BEGINNING OF INLINE: 84 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -961,17 +975,17 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 665 "src/parser.act"
+#line 701 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 969 "src/wsn/parser.c"
+#line 983 "src/wsn/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 83 */
+			/* END OF INLINE: 84 */
 			prod_list_Hof_Halts (lex_state, act_state, &ZIa);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -979,21 +993,21 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 987 "src/wsn/parser.c"
+#line 1001 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 624 "src/parser.act"
+#line 660 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 997 "src/wsn/parser.c"
+#line 1011 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1002,11 +1016,11 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 606 "src/parser.act"
+#line 642 "src/parser.act"
 
 		(ZIl) = ast_make_alt((*ZIt));
 	
-#line 1010 "src/wsn/parser.c"
+#line 1024 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1023,11 +1037,11 @@ ZL0:;
 }
 
 static void
-prod_94(lex_state lex_state, act_state act_state, map_term *ZIl)
+prod_95(lex_state lex_state, act_state act_state, map_term *ZIl)
 {
 	switch (CURRENT_TERMINAL) {
-	case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_STARTSTAR): case (TOK_EMPTY):
-	case (TOK_CS__LITERAL): case (TOK_ESC): case (TOK_CHAR): case (TOK_IDENT):
+	case (TOK_STARTGROUP): case (TOK_STARTOPT): case (TOK_STARTSTAR): case (TOK_ESC):
+	case (TOK_CHAR): case (TOK_IDENT): case (TOK_EMPTY): case (TOK_CS__LITERAL):
 		{
 			map_term ZIt;
 
@@ -1038,12 +1052,12 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 619 "src/parser.act"
+#line 655 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1047 "src/wsn/parser.c"
+#line 1061 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1061,7 +1075,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 807 "src/parser.act"
+#line 843 "src/parser.act"
 
 
 	static int
@@ -1190,6 +1204,6 @@ ZL1:;
 		return g;
 	}
 
-#line 1194 "src/wsn/parser.c"
+#line 1208 "src/wsn/parser.c"
 
 /* END OF FILE */

--- a/src/wsn/parser.h
+++ b/src/wsn/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 287 "src/parser.act"
+#line 315 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_wsn(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 809 "src/parser.act"
+#line 845 "src/parser.act"
 
 
 #line 31 "src/wsn/parser.h"

--- a/src/wsn/parser.sid
+++ b/src/wsn/parser.sid
@@ -12,6 +12,7 @@
 
 	char;
 	string;
+	txt;
 	count;
 
 	ast_rule;
@@ -45,14 +46,14 @@
 
 	EMPTY;
 	!NAME:       () -> (:string);
-	!CI_LITERAL: () -> (:string);
-	CS_LITERAL:  () -> (:string);
+	!CI_LITERAL: () -> (:txt);
+	CS_LITERAL:  () -> (:txt);
 	!PROSE:      () -> (:string);
 
-	!BINSTR:   () -> (:string);
-	!OCTSTR:   () -> (:string);
-	!DECSTR:   () -> (:string);
-	!HEXSTR:   () -> (:string);
+	!BINSTR:   () -> (:txt);
+	!OCTSTR:   () -> (:txt);
+	!DECSTR:   () -> (:txt);
+	!HEXSTR:   () -> (:txt);
 
 	!BINRANGE: () -> (:char, :char);
 	!OCTRANGE: () -> (:char, :char);
@@ -72,8 +73,8 @@
 
 	<make-empty-term>:       ()             -> (:ast_term);
 	<make-rule-term>:        (:string)      -> (:ast_term);
-	!<make-ci-literal-term>: (:string)      -> (:ast_term);
-	<make-cs-literal-term>:  (:string)      -> (:ast_term);
+	!<make-ci-literal-term>: (:txt)         -> (:ast_term);
+	<make-cs-literal-term>:  (:txt)         -> (:ast_term);
 	!<make-token-term>:      (:string)      -> (:ast_term);
 	!<make-prose-term>:      (:string)      -> (:ast_term);
 	<make-group-term>:       (:ast_alt)     -> (:ast_term);
@@ -117,8 +118,8 @@
 		t = <make-empty-term>;
 	||
 		body;
-		s = CS_LITERAL;
-		t = <make-cs-literal-term>(s);
+		x = CS_LITERAL;
+		t = <make-cs-literal-term>(x);
 	||
 		s = IDENT;
 		t = <make-rule-term>(s);

--- a/src/wsn/parser.sid
+++ b/src/wsn/parser.sid
@@ -38,16 +38,16 @@
 	STARTOPT;   ENDOPT;
 	STARTSTAR;  ENDSTAR;
 
-	EMPTY;
-	!NAME;
-	!CI_LITERAL;
-	CS_LITERAL;
-	!PROSE;
-
 	ESC:    () -> (:char);
 	CHAR:   () -> (:char);
 	IDENT:  () -> (:string);
 	!COUNT: () -> (:count);
+
+	EMPTY;
+	!NAME:       () -> (:string);
+	!CI_LITERAL: () -> (:string);
+	CS_LITERAL:  () -> (:string);
+	!PROSE:      () -> (:string);
 
 	!BINSTR:   () -> (:string);
 	!OCTSTR:   () -> (:string);
@@ -62,7 +62,6 @@
 %productions%
 
 	<pattern-char>:   (:char) -> ();
-	<pattern-buffer>: ()      -> (:string);
 
 	!<rep-one-or-more>: () -> (:count, :count);
 	<rep-zero-or-more>: () -> (:count, :count);
@@ -118,8 +117,7 @@
 		t = <make-empty-term>;
 	||
 		body;
-		CS_LITERAL;
-		s = <pattern-buffer>;
+		s = CS_LITERAL;
 		t = <make-cs-literal-term>(s);
 	||
 		s = IDENT;

--- a/src/xalloc.c
+++ b/src/xalloc.c
@@ -4,12 +4,14 @@
  * See LICENCE for the full copyright terms.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
 #include <stdlib.h>
 
 #include "xalloc.h"
+#include "txt.h"
 
 void *
 xmalloc(size_t size)
@@ -32,6 +34,22 @@ xstrdup(const char *s)
 
 	new = xmalloc(strlen(s) + 1);
 	return strcpy(new, s);
+}
+
+struct txt
+xtxtdup(const struct txt *t)
+{
+	struct txt new;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	new.n = t->n;
+	new.p = xmalloc(new.n);
+
+	memcpy(new.p, t->p, new.n);
+
+	return new;
 }
 
 void

--- a/src/xalloc.h
+++ b/src/xalloc.h
@@ -9,8 +9,11 @@
 
 #include <stddef.h>
 
+struct txt;
+
 void *xmalloc(size_t size);
 char *xstrdup(const char *s);
+struct txt xtxtdup(const struct txt *t);
 void xerror(const char *msg, ...);
 
 #endif


### PR DESCRIPTION
This PR implements #17, support for binary literals.

```
; ./build/bin/kgt -l abnf -e svg < examples/utf8.abnf 
```

![utf8](https://user-images.githubusercontent.com/1371085/53822140-13ed2200-3f67-11e9-8ced-bc447cf9b938.png)
