### PR TITLE
EBNF rendering to HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ PREFIX ?= /usr/local
 # layout
 SUBDIR += src/bnf
 SUBDIR += src/blab
+SUBDIR += src/ebnfhtml5
 SUBDIR += src/dot
 SUBDIR += src/abnf
 SUBDIR += src/iso-ebnf

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,7 @@ ${BUILD}/bin/kgt: ${BUILD}/src/xalloc.o
 
 .for part in ${PART:Mbnf} ${PART:Mblab} ${PART:Mabnf} ${PART:Miso-ebnf} ${PART:Mrbnf} \
 	${PART:Msid} ${PART:Mdot} ${PART:Mwsn} \
+	${PART:Mebnfhtml5} \
 	${PART:Mrrd} ${PART:Mrrdot} ${PART:Mrrdump} ${PART:Mrrtdump} \
 	${PART:Mrrparcon} ${PART:Mrrll} ${PART:Mrrta} ${PART:Mrrtext} \
 	${PART:Msvg} ${PART:Mhtml5}

--- a/src/ebnfhtml5/Makefile
+++ b/src/ebnfhtml5/Makefile
@@ -1,0 +1,11 @@
+.include "../../share/mk/top.mk"
+
+SRC += src/ebnfhtml5/output.c
+
+PART += ebnfhtml5
+
+.for src in ${SRC:Msrc/ebnfhtml5/*.c}
+${BUILD}/lib/ebnfhtml5.o:    ${BUILD}/${src:R}.o
+${BUILD}/lib/ebnfhtml5.opic: ${BUILD}/${src:R}.opic
+.endfor
+

--- a/src/ebnfhtml5/io.h
+++ b/src/ebnfhtml5/io.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef KGT_EBNFHTML5_IO_H
+#define KGT_EBNFHTML5_IO_H
+
+struct ast_rule;
+
+void
+ebnf_html5_output(const struct ast_rule *grammar);
+
+void
+ebnf_xhtml5_output(const struct ast_rule *grammar);
+
+#endif
+

--- a/src/ebnfhtml5/output.c
+++ b/src/ebnfhtml5/output.c
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2014-2019 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+/*
+ * Extended Backus-Naur Form Output, pretty-printed to HTML.
+ *
+ * This is my own made-up dialect. It's intended for ease
+ * of human consumption (i.e. in documentation), rather than
+ * to be parsed by machine.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "../txt.h"
+#include "../ast.h"
+#include "../rrd/node.h"
+
+#include "io.h"
+
+static void output_alt(const struct ast_alt *alt);
+
+static int
+atomic(const struct ast_term *term)
+{
+	assert(term != NULL);
+
+	switch (term->type) {
+	case TYPE_EMPTY:
+	case TYPE_RULE:
+	case TYPE_CI_LITERAL:
+	case TYPE_CS_LITERAL:
+	case TYPE_TOKEN:
+	case TYPE_PROSE:
+		return 1;
+
+	case TYPE_GROUP:
+		if (term->u.group->next != NULL) {
+			return 0;
+		}
+
+		if (term->u.group->terms->next != NULL) {
+			return 0;
+		}
+
+		return atomic(term->u.group->terms);
+	}
+}
+
+static const char *
+rep(unsigned min, unsigned max)
+{
+	if (min == 1 && max == 1) {
+		/* no operator */
+		return "\0";
+	}
+
+	if (min == 1 && max == 1) {
+		return "()";
+	}
+
+	if (min == 0 && max == 1) {
+		return "[]";
+	}
+
+	if (min == 0 && max == 0) {
+		return "{}";
+	}
+
+	return "()";
+}
+
+static void
+output_literal(const char *prefix, const struct txt *t)
+{
+	size_t i;
+
+	assert(t != NULL);
+	assert(t->p != NULL);
+
+	printf("<tt class='literal %s'>&quot;", prefix);
+
+	for (i = 0; i < t->n; i++) {
+		putc(t->p[i], stdout);
+	}
+
+	printf("&quot;</tt>");
+}
+
+static void
+output_term(const struct ast_term *term)
+{
+	const char *r;
+
+	r = rep(term->min, term->max);
+
+	if (!r[0] && !atomic(term)) {
+		r = "()";
+	}
+
+	if (r[0]) {
+		printf("<span class='rep'>%c</span> ", r[0]);
+	}
+
+	switch (term->type) {
+	case TYPE_EMPTY:
+		printf("<span class='empty'>&epsilon;</span>");
+		break;
+
+	case TYPE_RULE:
+		printf("<a href='#%s' class='rule' data-min='%u' data-max='%u'>",
+			term->u.rule->name, term->min, term->max);
+		printf("%s", term->u.rule->name);
+		printf("</a>");
+		break;
+
+	case TYPE_CI_LITERAL:
+		output_literal("ci", &term->u.literal);
+		break;
+
+	case TYPE_CS_LITERAL:
+		output_literal("cs", &term->u.literal);
+		break;
+
+	case TYPE_TOKEN:
+		printf("<span class='token'>");
+		printf("%s", term->u.token);
+		printf("</span>");
+		break;
+
+	case TYPE_PROSE:
+		printf("<span class='prose'>");
+		printf("%s", term->u.prose);
+		printf("</span>");
+		break;
+
+	case TYPE_GROUP: {
+			const struct ast_alt *alt;
+
+			for (alt = term->u.group; alt != NULL; alt = alt->next) {
+				output_alt(alt);
+
+				if (alt->next != NULL) {
+					printf("<span class='pipe'> | </span>");
+				}
+			}
+		}
+
+		break;
+	}
+
+	if (r[0]) {
+		printf(" <span class='rep'>%c</span>", r[1]);
+	}
+
+	if (term->max > 1) {
+		printf("<sub>(%u, %u)</sub>", term->min, term->max);
+	}
+}
+
+static void
+output_alt(const struct ast_alt *alt)
+{
+	const struct ast_term *term;
+
+	for (term = alt->terms; term != NULL; term = term->next) {
+		printf("<span class='alt'>");
+		output_term(term);
+		printf("</span>\n");
+
+		if (term->next != NULL) {
+			printf("<span class='cat'> </span>");
+		}
+	}
+}
+
+static void
+output_rule(const struct ast_rule *rule)
+{
+	const struct ast_alt *alt;
+
+	printf("  <dl class='bnf'>\n");
+
+	printf("    <dt>");
+	printf("<a name='%s'>", rule->name);
+	printf("%s", rule->name);
+	printf("</a>:");
+	printf("</dt>\n");
+
+	printf("    <dd>");
+
+	for (alt = rule->alts; alt != NULL; alt = alt->next) {
+		if (alt != rule->alts) {
+			printf("<span class='pipe'> | </span>");
+		}
+
+		printf("\n");
+		printf("      ");
+		output_alt(alt);
+
+		if (alt->next != NULL) {
+			printf("<br/>\n");
+			printf("      ");
+		}
+	}
+
+	printf("    </dd>\n");
+
+	printf("  </dl>\n");
+	printf("\n");
+}
+
+static void
+output(const struct ast_rule *grammar, int xml)
+{
+	const struct ast_rule *p;
+
+	printf(" <head>\n");
+	if (xml) {
+		printf("  <meta charset='UTF-8'/>\n");
+	}
+
+	printf("  <style>\n");
+
+	printf("    dl.bnf span.token {\n");
+	printf("    	text-transform: uppercase;\n");
+	printf("    }\n");
+	printf("    \n");
+	printf("    dl.bnf span.cat {\n");
+	printf("    	margin-right: 0.5ex;\n");
+	printf("    }\n");
+	printf("    \n");
+	printf("    dl.bnf dd > span.pipe {\n");
+	printf("    	float: left;\n");
+	printf("    	width: 1ex;\n");
+	printf("    	margin-left: -1.8ex;\n");
+	printf("    	text-align: right;\n");
+	printf("    	padding-right: .8ex; /* about the width of a space */\n");
+	printf("    }\n");
+	printf("    \n");
+	printf("    dl.bnf dt {\n");
+	printf("    	display: block;\n");
+	printf("    	min-width: 8em;\n");
+	printf("    	padding-right: 1em;\n");
+	printf("    }\n");
+	printf("    \n");
+	printf("    dl.bnf a.rule {\n");
+	printf("    	text-decoration: none;\n");
+	printf("    }\n");
+	printf("    \n");
+	printf("    dl.bnf a.rule:hover {\n");
+	printf("    	text-decoration: underline;\n");
+	printf("    }\n");
+	printf("    \n");
+	printf("    /* page stuff */\n");
+	printf("    dl.bnf { margin: 2em 4em; }\n");
+	printf("    dl.bnf dt { margin: 0.25em 0; }\n");
+	printf("    dl.bnf dd { margin-left: 2em; }\n");
+
+	printf("  </style>\n");
+
+	printf(" </head>\n");
+
+	printf(" <body>\n");
+
+	for (p = grammar; p != NULL; p = p->next) {
+		output_rule(p);
+	}
+
+	printf(" </body>\n");
+}
+
+void
+ebnf_html5_output(const struct ast_rule *grammar)
+{
+	printf("<!DOCTYPE html>\n");
+	printf("<html>\n");
+	printf("\n");
+
+	output(grammar, 0);
+
+	printf("</html>\n");
+}
+
+void
+ebnf_xhtml5_output(const struct ast_rule *grammar)
+{
+	printf("<?xml version='1.0' encoding='utf-8'?>\n");
+	printf("<!DOCTYPE html>\n");
+	printf("<html xml:lang='en' lang='en'\n");
+	printf("  xmlns='http://www.w3.org/1999/xhtml'\n");
+	printf("  xmlns:xlink='http://www.w3.org/1999/xlink'>\n");
+	printf("\n");
+
+	output(grammar, 1);
+
+	printf("</html>\n");
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
 
 #include "bnf/io.h"
 #include "blab/io.h"
+#include "ebnfhtml5/io.h"
 #include "wsn/io.h"
 #include "abnf/io.h"
 #include "iso-ebnf/io.h"
@@ -47,18 +48,20 @@ struct io {
 	enum ast_features ast_unsupported;
 	enum rrd_features rrd_unsupported;
 } io[] = {
-	{ "bnf",      bnf_input,      bnf_output,      bnf_ast_unsupported, 0 },
-	{ "blab",     NULL,           blab_output,     0, 0 },
-	{ "wsn",      wsn_input,      wsn_output,      wsn_ast_unsupported, 0 },
-	{ "abnf",     abnf_input,     abnf_output,     0, 0 },
-	{ "iso-ebnf", iso_ebnf_input, iso_ebnf_output, iso_ebnf_ast_unsupported, 0 },
-	{ "rbnf",     rbnf_input,     rbnf_output,     rbnf_ast_unsupported, 0 },
-	{ "sid",      NULL,           sid_output,      sid_ast_unsupported, 0 },
-	{ "dot",      NULL,           dot_output,      0, 0 },
-	{ "rrdot",    NULL,           rrdot_output,    0, 0 },
-	{ "rrdump",   NULL,           rrdump_output,   0, 0 },
-	{ "rrtdump",  NULL,           rrtdump_output,  0, 0 },
-	{ "rrparcon", NULL,           rrparcon_output, rrparcon_ast_unsupported, rrparcon_rrd_unsupported },
+	{ "bnf",        bnf_input,      bnf_output,         bnf_ast_unsupported, 0 },
+	{ "blab",       NULL,           blab_output,        0, 0 },
+	{ "ebnfhtml5",  NULL,           ebnf_html5_output,  0, 0 },
+	{ "ebnfxhtml5", NULL,           ebnf_xhtml5_output, 0, 0 },
+	{ "wsn",        wsn_input,      wsn_output,         wsn_ast_unsupported, 0 },
+	{ "abnf",       abnf_input,     abnf_output,        0, 0 },
+	{ "iso-ebnf",   iso_ebnf_input, iso_ebnf_output,    iso_ebnf_ast_unsupported, 0 },
+	{ "rbnf",       rbnf_input,     rbnf_output,        rbnf_ast_unsupported, 0 },
+	{ "sid",        NULL,           sid_output,         sid_ast_unsupported, 0 },
+	{ "dot",        NULL,           dot_output,         0, 0 },
+	{ "rrdot",      NULL,           rrdot_output,       0, 0 },
+	{ "rrdump",     NULL,           rrdump_output,      0, 0 },
+	{ "rrtdump",    NULL,           rrtdump_output,     0, 0 },
+	{ "rrparcon",   NULL,           rrparcon_output,    rrparcon_ast_unsupported, rrparcon_rrd_unsupported },
 	{ "rrll",     NULL,           rrll_output,     rrll_ast_unsupported, rrll_rrd_unsupported     },
 	{ "rrta",     NULL,           rrta_output,     rrta_ast_unsupported, rrta_rrd_unsupported     },
 	{ "rrtext",   NULL,           rrtext_output,   0, 0 },


### PR DESCRIPTION
This is a quick attempt at rendering an EBNF dialect for sake of human consumption rather than for parsing. It's a made-up dialect, formatted for presentation in documentation, and presented as HTML. I hope it sits well alongside the SVG railroad diagrams for the same purpose.

Most of the time it looks something like this:

![image](https://user-images.githubusercontent.com/1371085/54098483-bb75b480-43ac-11e9-8a5b-5b73483f2e2a.png)

and in worser cases like this:

![image](https://user-images.githubusercontent.com/1371085/54098554-0099e680-43ad-11e9-9252-2fa768a37f94.png)

There you can see the hex encoding for non-printable things, which I picked for the railroad diagrams because I think it's slightly less confusing for single characters than using an escape character.

The excess parentheses appear there because this rendering is directly from the AST rather than a more convenient form for rewriting and optimisations. Hence #24.