### PR TITLE
Support for invisible nodes to allow for some control over alignment in railroad diagrams

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,7 @@ SRC += src/ast_binary.c
 SRC += src/bitmap.c
 SRC += src/main.c
 SRC += src/rewrite_ci.c
+SRC += src/rewrite_invisible.c
 SRC += src/txt.c
 SRC += src/xalloc.c
 
@@ -22,6 +23,7 @@ ${BUILD}/bin/kgt: ${BUILD}/src/ast_binary.o
 ${BUILD}/bin/kgt: ${BUILD}/src/bitmap.o
 ${BUILD}/bin/kgt: ${BUILD}/src/main.o
 ${BUILD}/bin/kgt: ${BUILD}/src/rewrite_ci.o
+${BUILD}/bin/kgt: ${BUILD}/src/rewrite_invisible.o
 ${BUILD}/bin/kgt: ${BUILD}/src/txt.o
 ${BUILD}/bin/kgt: ${BUILD}/src/xalloc.o
 

--- a/src/abnf/io.h
+++ b/src/abnf/io.h
@@ -9,6 +9,11 @@
 
 struct ast_rule;
 
+/*
+ * We don't mark FEATURE_AST_INVISIBLE as unsupported here, because ABNF
+ * is supposed to be a source format; it's not presentational.
+ */
+
 struct ast_rule *
 abnf_input(int (*f)(void *opaque), void *opaque);
 

--- a/src/abnf/parser.c
+++ b/src/abnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 102 "src/parser.act"
+#line 103 "src/parser.act"
 
 
 	#include <assert.h>
@@ -65,6 +65,7 @@
 	struct act_state {
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
+		int invisible;
 	};
 
 	struct lex_state {
@@ -286,7 +287,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 290 "src/abnf/parser.c"
+#line 291 "src/abnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -328,12 +329,12 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 361 "src/parser.act"
+#line 362 "src/parser.act"
 
 		ZI104 = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 337 "src/abnf/parser.c"
+#line 338 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -358,7 +359,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 542 "src/parser.act"
+#line 543 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
@@ -367,7 +368,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 371 "src/abnf/parser.c"
+#line 372 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			switch (CURRENT_TERMINAL) {
@@ -379,23 +380,23 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 387 "src/abnf/parser.c"
+#line 388 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 399 "src/abnf/parser.c"
+#line 400 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -419,7 +420,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 533 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZI86) = 0;
@@ -428,7 +429,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZI86);
 	
-#line 432 "src/abnf/parser.c"
+#line 433 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			ADVANCE_LEXER;
@@ -440,14 +441,14 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 451 "src/abnf/parser.c"
+#line 452 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -491,21 +492,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 662 "src/parser.act"
+#line 673 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 499 "src/abnf/parser.c"
+#line 500 "src/abnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 709 "src/parser.act"
+#line 720 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 509 "src/abnf/parser.c"
+#line 510 "src/abnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -603,13 +604,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 340 "src/parser.act"
+#line 341 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 613 "src/abnf/parser.c"
+#line 614 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -622,12 +623,12 @@ ZL2_body:;
 			/* END OF INLINE: 75 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 519 "src/parser.act"
+#line 520 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 631 "src/abnf/parser.c"
+#line 632 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -658,7 +659,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 353 "src/parser.act"
+#line 354 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -675,13 +676,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 679 "src/abnf/parser.c"
+#line 680 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 590 "src/parser.act"
+#line 591 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -697,9 +698,9 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 
-		(ZIt) = ast_make_rule_term(r);
+		(ZIt) = ast_make_rule_term(act_state->invisible, r);
 	
-#line 703 "src/abnf/parser.c"
+#line 704 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -726,7 +727,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: BINRANGE */
 						{
-#line 466 "src/parser.act"
+#line 467 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, (unsigned char *) &ZIm, (unsigned char *) &ZIn,  2)) {
 			if (errno == ERANGE) {
@@ -738,7 +739,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 742 "src/abnf/parser.c"
+#line 743 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: BINRANGE */
 						ADVANCE_LEXER;
@@ -748,7 +749,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: DECRANGE */
 						{
-#line 490 "src/parser.act"
+#line 491 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, (unsigned char *) &ZIm, (unsigned char *) &ZIn, 10)) {
 			if (errno == ERANGE) {
@@ -760,7 +761,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 764 "src/abnf/parser.c"
+#line 765 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: DECRANGE */
 						ADVANCE_LEXER;
@@ -770,7 +771,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: HEXRANGE */
 						{
-#line 502 "src/parser.act"
+#line 503 "src/parser.act"
 
 		if (-1 == range(lex_state->buf.a, (unsigned char *) &ZIm, (unsigned char *) &ZIn, 16)) {
 			if (errno == ERANGE) {
@@ -782,7 +783,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 	
-#line 786 "src/abnf/parser.c"
+#line 787 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: HEXRANGE */
 						ADVANCE_LEXER;
@@ -795,7 +796,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			/* END OF INLINE: escrange */
 			/* BEGINNING OF ACTION: make-range-term */
 			{
-#line 638 "src/parser.act"
+#line 649 "src/parser.act"
 
 		struct ast_alt *a;
 		int i;
@@ -806,16 +807,16 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			struct ast_alt *new;
 			struct ast_term *t;
 
-			t = ast_make_char_term(i);
-			new = ast_make_alt(t);
+			t = ast_make_char_term(act_state->invisible, i);
+			new = ast_make_alt(act_state->invisible, t);
 
 			new->next = a;
 			a = new;
 		}
 
-		(ZIt) = ast_make_group_term(a);
+		(ZIt) = ast_make_group_term(act_state->invisible, a);
 	
-#line 819 "src/abnf/parser.c"
+#line 820 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-range-term */
 		}
@@ -831,7 +832,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: BINSTR */
 						{
-#line 386 "src/parser.act"
+#line 387 "src/parser.act"
 
 		ZIx.p = xstrdup(lex_state->buf.a);
 		if (ZIx.p == NULL) {
@@ -851,7 +852,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 855 "src/abnf/parser.c"
+#line 856 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: BINSTR */
 						ADVANCE_LEXER;
@@ -861,7 +862,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: DECSTR */
 						{
-#line 426 "src/parser.act"
+#line 427 "src/parser.act"
 
 		ZIx.p = xstrdup(lex_state->buf.a);
 		if (ZIx.p == NULL) {
@@ -881,7 +882,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 885 "src/abnf/parser.c"
+#line 886 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: DECSTR */
 						ADVANCE_LEXER;
@@ -891,7 +892,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF EXTRACT: HEXSTR */
 						{
-#line 446 "src/parser.act"
+#line 447 "src/parser.act"
 
 		ZIx.p = xstrdup(lex_state->buf.a);
 		if (ZIx.p == NULL) {
@@ -911,7 +912,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		/* TODO: free */
 	
-#line 915 "src/abnf/parser.c"
+#line 916 "src/abnf/parser.c"
 						}
 						/* END OF EXTRACT: HEXSTR */
 						ADVANCE_LEXER;
@@ -924,11 +925,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			/* END OF INLINE: escstr */
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 611 "src/parser.act"
+#line 612 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term(&(ZIx), 0);
+		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 0);
 	
-#line 932 "src/abnf/parser.c"
+#line 933 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -961,7 +962,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 353 "src/parser.act"
+#line 354 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -978,7 +979,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 982 "src/abnf/parser.c"
+#line 983 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -1009,11 +1010,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 						{
 							/* BEGINNING OF ACTION: err-expected-equals */
 							{
-#line 721 "src/parser.act"
+#line 732 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 1017 "src/abnf/parser.c"
+#line 1018 "src/abnf/parser.c"
 							}
 							/* END OF ACTION: err-expected-equals */
 						}
@@ -1027,11 +1028,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					}
 					/* BEGINNING OF ACTION: make-rule */
 					{
-#line 658 "src/parser.act"
+#line 669 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 1035 "src/abnf/parser.c"
+#line 1036 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: make-rule */
 				}
@@ -1057,11 +1058,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 						{
 							/* BEGINNING OF ACTION: err-expected-equals */
 							{
-#line 721 "src/parser.act"
+#line 732 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 1065 "src/abnf/parser.c"
+#line 1066 "src/abnf/parser.c"
 							}
 							/* END OF ACTION: err-expected-equals */
 						}
@@ -1070,13 +1071,13 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					/* END OF INLINE: 97 */
 					/* BEGINNING OF ACTION: current-rules */
 					{
-#line 690 "src/parser.act"
+#line 701 "src/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		(ZIl) = NULL;
 		goto ZL1;
 	
-#line 1080 "src/abnf/parser.c"
+#line 1081 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: current-rules */
 					prod_list_Hof_Halts (lex_state, act_state, &ZIa);
@@ -1086,23 +1087,23 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 					}
 					/* BEGINNING OF ACTION: find-rule */
 					{
-#line 695 "src/parser.act"
+#line 706 "src/parser.act"
 
 		assert((ZIs) != NULL);
 
 		(ZIr) = ast_find_rule((ZIl), (ZIs));
 	
-#line 1096 "src/abnf/parser.c"
+#line 1097 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: find-rule */
 					/* BEGINNING OF ACTION: add-alts */
 					{
-#line 702 "src/parser.act"
+#line 713 "src/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		goto ZL1;
 	
-#line 1106 "src/abnf/parser.c"
+#line 1107 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: add-alts */
 				}
@@ -1133,11 +1134,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 717 "src/parser.act"
+#line 728 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 1141 "src/abnf/parser.c"
+#line 1142 "src/abnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
@@ -1163,12 +1164,12 @@ prod_87(lex_state lex_state, act_state act_state, map_count *ZOmax)
 		{
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 361 "src/parser.act"
+#line 362 "src/parser.act"
 
 		ZImax = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 1172 "src/abnf/parser.c"
+#line 1173 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -1180,7 +1181,7 @@ prod_87(lex_state lex_state, act_state act_state, map_count *ZOmax)
 
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 533 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZI89) = 0;
 		(ZImax) = 0;
@@ -1189,7 +1190,7 @@ prod_87(lex_state lex_state, act_state act_state, map_count *ZOmax)
 		(void) (ZI89);
 		(void) (ZImax);
 	
-#line 1193 "src/abnf/parser.c"
+#line 1194 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 		}
@@ -1215,7 +1216,7 @@ prod_101(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 677 "src/parser.act"
+#line 688 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -1227,7 +1228,7 @@ prod_101(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 1231 "src/abnf/parser.c"
+#line 1232 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -1269,11 +1270,11 @@ prod_102(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 713 "src/parser.act"
+#line 724 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 1277 "src/abnf/parser.c"
+#line 1278 "src/abnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
@@ -1287,21 +1288,21 @@ prod_102(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 1295 "src/abnf/parser.c"
+#line 1296 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 672 "src/parser.act"
+#line 683 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1305 "src/abnf/parser.c"
+#line 1306 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1310,11 +1311,11 @@ prod_102(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 1318 "src/abnf/parser.c"
+#line 1319 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1348,12 +1349,12 @@ prod_103(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 667 "src/parser.act"
+#line 678 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1357 "src/abnf/parser.c"
+#line 1358 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1393,11 +1394,11 @@ prod_factor_C_Celement(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 1401 "src/abnf/parser.c"
+#line 1402 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -1445,14 +1446,14 @@ prod_105(lex_state lex_state, act_state act_state, map_count *ZI104, map_term *Z
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (*ZI104) || !(ZImax));
 
 		(ZIt)->min = (*ZI104);
 		(ZIt)->max = (ZImax);
 	
-#line 1456 "src/abnf/parser.c"
+#line 1457 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -1468,14 +1469,14 @@ prod_105(lex_state lex_state, act_state act_state, map_count *ZI104, map_term *Z
 			}
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((*ZI104) >= (*ZI104) || !(*ZI104));
 
 		(ZIt)->min = (*ZI104);
 		(ZIt)->max = (*ZI104);
 	
-#line 1479 "src/abnf/parser.c"
+#line 1480 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -1505,18 +1506,18 @@ prod_106(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: CI_LITERAL */
 			{
-#line 371 "src/parser.act"
+#line 372 "src/parser.act"
 
 		ZIx.p = pattern_buffer(lex_state);
 		ZIx.n = strlen(ZIx.p);
 	
-#line 1514 "src/abnf/parser.c"
+#line 1515 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: CI_LITERAL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-ci-literal-term */
 			{
-#line 603 "src/parser.act"
+#line 604 "src/parser.act"
 
 		size_t i;
 
@@ -1525,9 +1526,9 @@ prod_106(lex_state lex_state, act_state act_state, map_term *ZOt)
 			((char *) (ZIx).p)[i] = tolower((unsigned char) (ZIx).p[i]);
 		}
 
-		(ZIt) = ast_make_literal_term(&(ZIx), 1);
+		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 1);
 	
-#line 1531 "src/abnf/parser.c"
+#line 1532 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-ci-literal-term */
 		}
@@ -1538,22 +1539,22 @@ prod_106(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: CS_LITERAL */
 			{
-#line 376 "src/parser.act"
+#line 377 "src/parser.act"
 
 		ZIx.p = pattern_buffer(lex_state);
 		ZIx.n = strlen(ZIx.p);
 	
-#line 1547 "src/abnf/parser.c"
+#line 1548 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: CS_LITERAL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 611 "src/parser.act"
+#line 612 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term(&(ZIx), 0);
+		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 0);
 	
-#line 1557 "src/abnf/parser.c"
+#line 1558 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -1564,27 +1565,37 @@ prod_106(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: PROSE */
 			{
-#line 381 "src/parser.act"
+#line 382 "src/parser.act"
 
 		ZIs = pattern_buffer(lex_state);
 	
-#line 1572 "src/abnf/parser.c"
+#line 1573 "src/abnf/parser.c"
 			}
 			/* END OF EXTRACT: PROSE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-prose-term */
 			{
-#line 621 "src/parser.act"
+#line 622 "src/parser.act"
 
 		const char *s;
 
 		s = xstrdup(trim((char *) (ZIs)));
 
-		(ZIt) = ast_make_prose_term(s);
-
 		free((void *) (ZIs));
+
+		if (!strcmp(s, "kgt:invisible")) {
+			act_state->invisible = 1;
+
+			(ZIt) = ast_make_empty_term(act_state->invisible);
+		} else if (!strcmp(s, "kgt:visible")) {
+			act_state->invisible = 0;
+
+			(ZIt) = ast_make_empty_term(act_state->invisible);
+		} else {
+			(ZIt) = ast_make_prose_term(act_state->invisible, s);
+		}
 	
-#line 1588 "src/abnf/parser.c"
+#line 1599 "src/abnf/parser.c"
 			}
 			/* END OF ACTION: make-prose-term */
 		}
@@ -1604,7 +1615,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 856 "src/parser.act"
+#line 869 "src/parser.act"
 
 
 	static int
@@ -1673,6 +1684,8 @@ ZL0:;
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
 
+		act_state->invisible = 0;
+
 		ADVANCE_LEXER;
 		FORM_ENTRY(lex_state, act_state, &g);
 
@@ -1734,6 +1747,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1738 "src/abnf/parser.c"
+#line 1751 "src/abnf/parser.c"
 
 /* END OF FILE */

--- a/src/abnf/parser.h
+++ b/src/abnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 315 "src/parser.act"
+#line 316 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_abnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 858 "src/parser.act"
+#line 871 "src/parser.act"
 
 
 #line 31 "src/abnf/parser.h"

--- a/src/ast.c
+++ b/src/ast.c
@@ -31,7 +31,7 @@ isalphastr(const struct txt *t)
 }
 
 struct ast_term *
-ast_make_empty_term(void)
+ast_make_empty_term(int invisible)
 {
 	struct ast_term *new;
 
@@ -42,11 +42,13 @@ ast_make_empty_term(void)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_term *
-ast_make_rule_term(struct ast_rule *rule)
+ast_make_rule_term(int invisible, struct ast_rule *rule)
 {
 	struct ast_term *new;
 
@@ -60,11 +62,13 @@ ast_make_rule_term(struct ast_rule *rule)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_term *
-ast_make_char_term(char c)
+ast_make_char_term(int invisible, char c)
 {
 	struct ast_term *new;
 	char *a;
@@ -81,11 +85,13 @@ ast_make_char_term(char c)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_term *
-ast_make_literal_term(const struct txt *literal, int ci)
+ast_make_literal_term(int invisible, const struct txt *literal, int ci)
 {
 	struct ast_term *new;
 
@@ -105,11 +111,13 @@ ast_make_literal_term(const struct txt *literal, int ci)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_term *
-ast_make_token_term(const char *token)
+ast_make_token_term(int invisible, const char *token)
 {
 	struct ast_term *new;
 
@@ -123,11 +131,13 @@ ast_make_token_term(const char *token)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_term *
-ast_make_prose_term(const char *prose)
+ast_make_prose_term(int invisible, const char *prose)
 {
 	struct ast_term *new;
 
@@ -141,11 +151,13 @@ ast_make_prose_term(const char *prose)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_term *
-ast_make_group_term(struct ast_alt *group)
+ast_make_group_term(int invisible, struct ast_alt *group)
 {
 	struct ast_term *new;
 
@@ -157,17 +169,21 @@ ast_make_group_term(struct ast_alt *group)
 	new->min = 1;
 	new->max = 1;
 
+	new->invisible = invisible;
+
 	return new;
 }
 
 struct ast_alt *
-ast_make_alt(struct ast_term *terms)
+ast_make_alt(int invisible, struct ast_term *terms)
 {
 	struct ast_alt *new;
 
 	new = xmalloc(sizeof *new);
 	new->terms = terms;
 	new->next  = NULL;
+
+	new->invisible = invisible;
 
 	return new;
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -222,6 +222,21 @@ ast_find_rule(const struct ast_rule *grammar, const char *name)
 void
 ast_free_rule(struct ast_rule *rule)
 {
+	/* XXX: free contents */
 	free(rule);
+}
+
+void
+ast_free_alt(struct ast_alt *alt)
+{
+	/* XXX: free contents */
+	free(alt);
+}
+
+void
+ast_free_term(struct ast_term *term)
+{
+	/* XXX: free contents */
+	free(term);
 }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -45,6 +45,8 @@ struct ast_term {
 	unsigned int min;
 	unsigned int max; /* false (0) for unlimited */
 
+	int invisible;
+
 	struct ast_term *next;
 };
 
@@ -56,6 +58,8 @@ struct ast_term {
 struct ast_alt {
 	struct ast_term *terms;
 	/* TODO: struct ast_term *negs; - negative terms here */
+
+	int invisible;
 
 	struct ast_alt *next;
 };
@@ -75,28 +79,28 @@ struct ast_rule {
 };
 
 struct ast_term *
-ast_make_empty_term(void);
+ast_make_empty_term(int invisible);
 
 struct ast_term *
-ast_make_rule_term(struct ast_rule *rule);
+ast_make_rule_term(int invisible, struct ast_rule *rule);
 
 struct ast_term *
-ast_make_char_term(char c);
+ast_make_char_term(int invisible, char c);
 
 struct ast_term *
-ast_make_literal_term(const struct txt *literal, int ci);
+ast_make_literal_term(int invisible, const struct txt *literal, int ci);
 
 struct ast_term *
-ast_make_token_term(const char *token);
+ast_make_token_term(int invisible, const char *token);
 
 struct ast_term *
-ast_make_prose_term(const char *prose);
+ast_make_prose_term(int invisible, const char *prose);
 
 struct ast_term *
-ast_make_group_term(struct ast_alt *group);
+ast_make_group_term(int invisible, struct ast_alt *group);
 
 struct ast_alt *
-ast_make_alt(struct ast_term *terms);
+ast_make_alt(int invisible, struct ast_term *terms);
 
 struct ast_rule *
 ast_make_rule(const char *name, struct ast_alt *alts);

--- a/src/ast.h
+++ b/src/ast.h
@@ -12,7 +12,8 @@ struct ast_alt;
 enum ast_features {
     FEATURE_AST_CI_LITERAL = 1 << 0,
     FEATURE_AST_PROSE      = 1 << 1,
-    FEATURE_AST_BINARY     = 1 << 2
+    FEATURE_AST_BINARY     = 1 << 2,
+    FEATURE_AST_INVISIBLE  = 1 << 3
 };
 
 /*
@@ -110,6 +111,12 @@ ast_find_rule(const struct ast_rule *grammar, const char *name);
 
 void
 ast_free_rule(struct ast_rule *rule);
+
+void
+ast_free_alt(struct ast_alt *alt);
+
+void
+ast_free_term(struct ast_term *term);
 
 int
 ast_binary(const struct ast_rule *ast);

--- a/src/blab/io.h
+++ b/src/blab/io.h
@@ -9,6 +9,8 @@
 
 struct ast_rule;
 
+#define blab_ast_unsupported (FEATURE_AST_INVISIBLE)
+
 void
 blab_output(const struct ast_rule *grammar);
 

--- a/src/blab/output.c
+++ b/src/blab/output.c
@@ -125,6 +125,7 @@ output_term(const struct ast_term *term)
 	int a;
 
 	assert(term != NULL);
+	assert(!term->invisible);
 
 	a = atomic(term);
 
@@ -208,6 +209,8 @@ static void
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
+
+	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		output_term(term);

--- a/src/bnf/io.h
+++ b/src/bnf/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define bnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
+#define bnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 struct ast_rule *
 bnf_input(int (*f)(void *opaque), void *opaque);

--- a/src/bnf/output.c
+++ b/src/bnf/output.c
@@ -24,6 +24,7 @@ static void
 output_term(const struct ast_term *term)
 {
 	assert(term->type != TYPE_GROUP);
+	assert(!term->invisible);
 	/* TODO: semantic checks ought to find if we can output to this language; groups cannot */
 
 	/* BNF cannot express term repetition; TODO: semantic checks for this */
@@ -68,6 +69,8 @@ static void
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
+
+	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		output_term(term);

--- a/src/bnf/parser.c
+++ b/src/bnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 102 "src/parser.act"
+#line 103 "src/parser.act"
 
 
 	#include <assert.h>
@@ -65,6 +65,7 @@
 	struct act_state {
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
+		int invisible;
 	};
 
 	struct lex_state {
@@ -286,7 +287,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 290 "src/bnf/parser.c"
+#line 291 "src/bnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -426,13 +427,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 340 "src/parser.act"
+#line 341 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 436 "src/bnf/parser.c"
+#line 437 "src/bnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -445,12 +446,12 @@ ZL2_body:;
 			/* END OF INLINE: 68 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 519 "src/parser.act"
+#line 520 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 454 "src/bnf/parser.c"
+#line 455 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -489,21 +490,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 662 "src/parser.act"
+#line 673 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 497 "src/bnf/parser.c"
+#line 498 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 709 "src/parser.act"
+#line 720 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 507 "src/bnf/parser.c"
+#line 508 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -522,11 +523,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 578 "src/parser.act"
+#line 579 "src/parser.act"
 
-		(ZIt) = ast_make_empty_term();
+		(ZIt) = ast_make_empty_term(act_state->invisible);
 	
-#line 530 "src/bnf/parser.c"
+#line 531 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -571,11 +572,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_NAME):
 			/* BEGINNING OF EXTRACT: NAME */
 			{
-#line 367 "src/parser.act"
+#line 368 "src/parser.act"
 
 		ZIs = pattern_buffer(lex_state);
 	
-#line 579 "src/bnf/parser.c"
+#line 580 "src/bnf/parser.c"
 			}
 			/* END OF EXTRACT: NAME */
 			break;
@@ -602,11 +603,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 721 "src/parser.act"
+#line 732 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 610 "src/bnf/parser.c"
+#line 611 "src/bnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
@@ -620,11 +621,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 658 "src/parser.act"
+#line 669 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 628 "src/bnf/parser.c"
+#line 629 "src/bnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
 		/* BEGINNING OF INLINE: 83 */
@@ -648,11 +649,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 717 "src/parser.act"
+#line 728 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 656 "src/bnf/parser.c"
+#line 657 "src/bnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
@@ -683,7 +684,7 @@ prod_90(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 677 "src/parser.act"
+#line 688 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -695,7 +696,7 @@ prod_90(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 699 "src/bnf/parser.c"
+#line 700 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -737,11 +738,11 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 713 "src/parser.act"
+#line 724 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 745 "src/bnf/parser.c"
+#line 746 "src/bnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
@@ -755,21 +756,21 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 763 "src/bnf/parser.c"
+#line 764 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 672 "src/parser.act"
+#line 683 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 773 "src/bnf/parser.c"
+#line 774 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -778,11 +779,11 @@ prod_91(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 786 "src/bnf/parser.c"
+#line 787 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -813,12 +814,12 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 667 "src/parser.act"
+#line 678 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 822 "src/bnf/parser.c"
+#line 823 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -846,22 +847,22 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: CS_LITERAL */
 			{
-#line 376 "src/parser.act"
+#line 377 "src/parser.act"
 
 		ZIx.p = pattern_buffer(lex_state);
 		ZIx.n = strlen(ZIx.p);
 	
-#line 855 "src/bnf/parser.c"
+#line 856 "src/bnf/parser.c"
 			}
 			/* END OF EXTRACT: CS_LITERAL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 611 "src/parser.act"
+#line 612 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term(&(ZIx), 0);
+		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 0);
 	
-#line 865 "src/bnf/parser.c"
+#line 866 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -872,17 +873,17 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: NAME */
 			{
-#line 367 "src/parser.act"
+#line 368 "src/parser.act"
 
 		ZIs = pattern_buffer(lex_state);
 	
-#line 880 "src/bnf/parser.c"
+#line 881 "src/bnf/parser.c"
 			}
 			/* END OF EXTRACT: NAME */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 590 "src/parser.act"
+#line 591 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -898,9 +899,9 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 
-		(ZIt) = ast_make_rule_term(r);
+		(ZIt) = ast_make_rule_term(act_state->invisible, r);
 	
-#line 904 "src/bnf/parser.c"
+#line 905 "src/bnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -920,7 +921,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 856 "src/parser.act"
+#line 869 "src/parser.act"
 
 
 	static int
@@ -989,6 +990,8 @@ ZL0:;
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
 
+		act_state->invisible = 0;
+
 		ADVANCE_LEXER;
 		FORM_ENTRY(lex_state, act_state, &g);
 
@@ -1050,6 +1053,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1054 "src/bnf/parser.c"
+#line 1057 "src/bnf/parser.c"
 
 /* END OF FILE */

--- a/src/bnf/parser.h
+++ b/src/bnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 315 "src/parser.act"
+#line 316 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_bnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 858 "src/parser.act"
+#line 871 "src/parser.act"
 
 
 #line 31 "src/bnf/parser.h"

--- a/src/dot/output.c
+++ b/src/dot/output.c
@@ -108,11 +108,21 @@ output_term(const struct ast_rule *grammar,
 {
 	assert(term->max >= term->min || !term->max);
 
-	printf("\t\"a%p\" -> \"t%p\";\n",
+	printf("\t\"a%p\" -> \"t%p\"",
 		(void *) alt, (void *) term);
+	if (term->invisible) {
+		printf(" [ color = blue, style = dashed ]");
+	}
+	printf(";\n");
 
-	printf("\t\"t%p\" [ shape = record, label = \"",
+	printf("\t\"t%p\" [ shape = record, ",
 		(void *) term);
+
+	if (term->invisible) {
+		printf("color = blue, fontcolor = blue, style = \"rounded,dashed\", ");
+	}
+
+	printf("label = \"");
 
 	if (term->min == 1 && term->max == 1) {
 		/* nothing */
@@ -175,8 +185,14 @@ output_term(const struct ast_rule *grammar,
 	case TYPE_CS_LITERAL:
 	case TYPE_TOKEN:
 	case TYPE_PROSE:
-		printf("\t\"t%p\" [ style = filled ];\n",
+		printf("\t\"t%p\" [ style = filled",
 			(void *) term);
+
+		if (term->invisible) {
+			printf(", color = blue, fillcolor = aliceblue, style = \"dashed,filled\" ");
+		}
+
+		printf("];\n");
 		break;
 
 	case TYPE_GROUP:
@@ -191,8 +207,14 @@ output_alt(const struct ast_rule *grammar,
 {
 	const struct ast_term *term;
 
-	printf("\t\"a%p\" [ label = \"|\" ];\n",
+	printf("\t\"a%p\" [ label = \"|\"",
 		(void *) alt);
+
+if (alt->invisible) {
+	printf(", color = blue ");
+}
+
+	printf("];\n");
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		output_term(grammar, alt, term);

--- a/src/ebnfhtml5/io.h
+++ b/src/ebnfhtml5/io.h
@@ -9,6 +9,12 @@
 
 struct ast_rule;
 
+/*
+ * We mark FEATURE_AST_INVISIBLE as unsupported here, because this EBNF
+ * is supposed to be a presentational format.
+ */
+#define ebnf_html5_ast_unsupported (FEATURE_AST_INVISIBLE)
+
 void
 ebnf_html5_output(const struct ast_rule *grammar);
 

--- a/src/ebnfhtml5/output.c
+++ b/src/ebnfhtml5/output.c
@@ -137,6 +137,9 @@ output_term(const struct ast_term *term)
 {
 	const char *r;
 
+	assert(term != NULL);
+	assert(!term->invisible);
+
 	r = rep(term->min, term->max);
 
 	if (!r[0] && !atomic(term)) {
@@ -209,6 +212,9 @@ static void
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
+
+	assert(alt != NULL);
+	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		printf("<span class='alt'>");

--- a/src/iso-ebnf/io.h
+++ b/src/iso-ebnf/io.h
@@ -9,6 +9,11 @@
 
 struct ast_rule;
 
+/*
+ * We don't mark FEATURE_AST_INVISIBLE as unsupported here, because this EBNF
+ * is supposed to be a source format; it's not presentational.
+ */
+
 #define iso_ebnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_PROSE | FEATURE_AST_BINARY)
 
 struct ast_rule *

--- a/src/iso-ebnf/parser.c
+++ b/src/iso-ebnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 102 "src/parser.act"
+#line 103 "src/parser.act"
 
 
 	#include <assert.h>
@@ -65,6 +65,7 @@
 	struct act_state {
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
+		int invisible;
 	};
 
 	struct lex_state {
@@ -286,7 +287,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 290 "src/iso-ebnf/parser.c"
+#line 291 "src/iso-ebnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -340,11 +341,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 348 "src/iso-ebnf/parser.c"
+#line 349 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -369,16 +370,16 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 377 "src/iso-ebnf/parser.c"
+#line 378 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 542 "src/parser.act"
+#line 543 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
@@ -387,19 +388,19 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 391 "src/iso-ebnf/parser.c"
+#line 392 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 403 "src/iso-ebnf/parser.c"
+#line 404 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -424,16 +425,16 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 432 "src/iso-ebnf/parser.c"
+#line 433 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 533 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
@@ -442,19 +443,19 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 446 "src/iso-ebnf/parser.c"
+#line 447 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 458 "src/iso-ebnf/parser.c"
+#line 459 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -505,21 +506,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 662 "src/parser.act"
+#line 673 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 513 "src/iso-ebnf/parser.c"
+#line 514 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 709 "src/parser.act"
+#line 720 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 523 "src/iso-ebnf/parser.c"
+#line 524 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -617,13 +618,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 340 "src/parser.act"
+#line 341 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 627 "src/iso-ebnf/parser.c"
+#line 628 "src/iso-ebnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -636,12 +637,12 @@ ZL2_body:;
 			/* END OF INLINE: 73 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 519 "src/parser.act"
+#line 520 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 645 "src/iso-ebnf/parser.c"
+#line 646 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -672,7 +673,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 353 "src/parser.act"
+#line 354 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -689,13 +690,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 693 "src/iso-ebnf/parser.c"
+#line 694 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 590 "src/parser.act"
+#line 591 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -711,9 +712,9 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 
-		(ZIt) = ast_make_rule_term(r);
+		(ZIt) = ast_make_rule_term(act_state->invisible, r);
 	
-#line 717 "src/iso-ebnf/parser.c"
+#line 718 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -732,11 +733,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		{
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 578 "src/parser.act"
+#line 579 "src/parser.act"
 
-		(ZIt) = ast_make_empty_term();
+		(ZIt) = ast_make_empty_term(act_state->invisible);
 	
-#line 740 "src/iso-ebnf/parser.c"
+#line 741 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -768,7 +769,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 353 "src/parser.act"
+#line 354 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -785,7 +786,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 789 "src/iso-ebnf/parser.c"
+#line 790 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -809,11 +810,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 721 "src/parser.act"
+#line 732 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 817 "src/iso-ebnf/parser.c"
+#line 818 "src/iso-ebnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
@@ -827,11 +828,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 658 "src/parser.act"
+#line 669 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 835 "src/iso-ebnf/parser.c"
+#line 836 "src/iso-ebnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
 		/* BEGINNING OF INLINE: 91 */
@@ -850,11 +851,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 717 "src/parser.act"
+#line 728 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 858 "src/iso-ebnf/parser.c"
+#line 859 "src/iso-ebnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
@@ -882,12 +883,12 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 361 "src/parser.act"
+#line 362 "src/parser.act"
 
 		ZIn = strtoul(lex_state->buf.a, NULL, 10);
 		/* TODO: range check */
 	
-#line 891 "src/iso-ebnf/parser.c"
+#line 892 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -905,7 +906,7 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			}
 			/* BEGINNING OF ACTION: mul-repeat */
 			{
-#line 558 "src/parser.act"
+#line 559 "src/parser.act"
 
 		assert((ZIn) > 0);
 
@@ -924,7 +925,7 @@ prod_repeatable_Hfactor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(ZIt)->min *= (ZIn);
 		(ZIt)->max *= (ZIn);
 	
-#line 928 "src/iso-ebnf/parser.c"
+#line 929 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: mul-repeat */
 		}
@@ -964,7 +965,7 @@ prod_95(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 677 "src/parser.act"
+#line 688 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -976,7 +977,7 @@ prod_95(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 980 "src/iso-ebnf/parser.c"
+#line 981 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -1018,11 +1019,11 @@ prod_96(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 713 "src/parser.act"
+#line 724 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 1026 "src/iso-ebnf/parser.c"
+#line 1027 "src/iso-ebnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
@@ -1036,21 +1037,21 @@ prod_96(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 1044 "src/iso-ebnf/parser.c"
+#line 1045 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 672 "src/parser.act"
+#line 683 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1054 "src/iso-ebnf/parser.c"
+#line 1055 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1059,11 +1060,11 @@ prod_96(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 1067 "src/iso-ebnf/parser.c"
+#line 1068 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1095,11 +1096,11 @@ prod_97(lex_state lex_state, act_state act_state)
 			}
 			/* BEGINNING OF ACTION: err-unimplemented-except */
 			{
-#line 725 "src/parser.act"
+#line 736 "src/parser.act"
 
 		err_unimplemented(lex_state, "\"except\" productions");
 	
-#line 1103 "src/iso-ebnf/parser.c"
+#line 1104 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: err-unimplemented-except */
 		}
@@ -1131,12 +1132,12 @@ prod_98(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 667 "src/parser.act"
+#line 678 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1140 "src/iso-ebnf/parser.c"
+#line 1141 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1164,22 +1165,22 @@ prod_99(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: CS_LITERAL */
 			{
-#line 376 "src/parser.act"
+#line 377 "src/parser.act"
 
 		ZIx.p = pattern_buffer(lex_state);
 		ZIx.n = strlen(ZIx.p);
 	
-#line 1173 "src/iso-ebnf/parser.c"
+#line 1174 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: CS_LITERAL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 611 "src/parser.act"
+#line 612 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term(&(ZIx), 0);
+		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 0);
 	
-#line 1183 "src/iso-ebnf/parser.c"
+#line 1184 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -1190,27 +1191,37 @@ prod_99(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: PROSE */
 			{
-#line 381 "src/parser.act"
+#line 382 "src/parser.act"
 
 		ZIs = pattern_buffer(lex_state);
 	
-#line 1198 "src/iso-ebnf/parser.c"
+#line 1199 "src/iso-ebnf/parser.c"
 			}
 			/* END OF EXTRACT: PROSE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-prose-term */
 			{
-#line 621 "src/parser.act"
+#line 622 "src/parser.act"
 
 		const char *s;
 
 		s = xstrdup(trim((char *) (ZIs)));
 
-		(ZIt) = ast_make_prose_term(s);
-
 		free((void *) (ZIs));
+
+		if (!strcmp(s, "kgt:invisible")) {
+			act_state->invisible = 1;
+
+			(ZIt) = ast_make_empty_term(act_state->invisible);
+		} else if (!strcmp(s, "kgt:visible")) {
+			act_state->invisible = 0;
+
+			(ZIt) = ast_make_empty_term(act_state->invisible);
+		} else {
+			(ZIt) = ast_make_prose_term(act_state->invisible, s);
+		}
 	
-#line 1214 "src/iso-ebnf/parser.c"
+#line 1225 "src/iso-ebnf/parser.c"
 			}
 			/* END OF ACTION: make-prose-term */
 		}
@@ -1254,7 +1265,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 856 "src/parser.act"
+#line 869 "src/parser.act"
 
 
 	static int
@@ -1323,6 +1334,8 @@ ZL0:;
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
 
+		act_state->invisible = 0;
+
 		ADVANCE_LEXER;
 		FORM_ENTRY(lex_state, act_state, &g);
 
@@ -1384,6 +1397,6 @@ ZL0:;
 		return g;
 	}
 
-#line 1388 "src/iso-ebnf/parser.c"
+#line 1401 "src/iso-ebnf/parser.c"
 
 /* END OF FILE */

--- a/src/iso-ebnf/parser.h
+++ b/src/iso-ebnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 315 "src/parser.act"
+#line 316 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_iso_Hebnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 858 "src/parser.act"
+#line 871 "src/parser.act"
 
 
 #line 31 "src/iso-ebnf/parser.h"

--- a/src/main.c
+++ b/src/main.c
@@ -51,9 +51,9 @@ struct io {
 	enum rrd_features rrd_unsupported;
 } io[] = {
 	{ "bnf",        bnf_input,      bnf_output,         bnf_ast_unsupported, 0 },
-	{ "blab",       NULL,           blab_output,        0, 0 },
-	{ "ebnfhtml5",  NULL,           ebnf_html5_output,  0, 0 },
-	{ "ebnfxhtml5", NULL,           ebnf_xhtml5_output, 0, 0 },
+	{ "blab",       NULL,           blab_output,        blab_ast_unsupported, 0 },
+	{ "ebnfhtml5",  NULL,           ebnf_html5_output,  ebnf_html5_ast_unsupported, 0 },
+	{ "ebnfxhtml5", NULL,           ebnf_xhtml5_output, ebnf_html5_ast_unsupported, 0 },
 	{ "wsn",        wsn_input,      wsn_output,         wsn_ast_unsupported, 0 },
 	{ "abnf",       abnf_input,     abnf_output,        0, 0 },
 	{ "iso-ebnf",   iso_ebnf_input, iso_ebnf_output,    iso_ebnf_ast_unsupported, 0 },
@@ -200,6 +200,7 @@ main(int argc, char *argv[])
 			/* TODO: option to query if output is possible without rewriting */
 			switch (v & -v) {
 			case FEATURE_AST_CI_LITERAL: rewrite_ci_literals(g); break;
+			case FEATURE_AST_INVISIBLE:  rewrite_invisible(g);   break;
 
 			case FEATURE_AST_BINARY:
 				if (ast_binary(g)) {

--- a/src/parser.act
+++ b/src/parser.act
@@ -84,6 +84,7 @@
 	struct act_state {
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
+		int invisible;
 	};
 
 	struct lex_state {
@@ -575,7 +576,7 @@
 
 
 	<make-empty-term>: () -> (t :ast_term) = @{
-		@t = ast_make_empty_term();
+		@t = ast_make_empty_term(act_state->invisible);
 	@};
 
 	<make-rule-term>: (n :string) -> (t :ast_term) = @{
@@ -593,7 +594,7 @@
 			@!;
 		}
 
-		@t = ast_make_rule_term(r);
+		@t = ast_make_rule_term(act_state->invisible, r);
 	@};
 
 	<make-ci-literal-term>: (x :txt) -> (t :ast_term) = @{
@@ -604,15 +605,15 @@
 			((char *) @x.p)[i] = tolower((unsigned char) @x.p[i]);
 		}
 
-		@t = ast_make_literal_term(&@x, 1);
+		@t = ast_make_literal_term(act_state->invisible, &@x, 1);
 	@};
 
 	<make-cs-literal-term>: (x :txt) -> (t :ast_term) = @{
-		@t = ast_make_literal_term(&@x, 0);
+		@t = ast_make_literal_term(act_state->invisible, &@x, 0);
 	@};
 
 	<make-token-term>: (n :string) -> (t :ast_term) = @{
-		@t = ast_make_token_term(@n);
+		@t = ast_make_token_term(act_state->invisible, @n);
 	@};
 
 	<make-prose-term>: (l :string) -> (t :ast_term) = @{
@@ -620,13 +621,23 @@
 
 		s = xstrdup(trim((char *) @l));
 
-		@t = ast_make_prose_term(s);
-
 		free((void *) @l);
+
+		if (!strcmp(s, "kgt:invisible")) {
+			act_state->invisible = 1;
+
+			@t = ast_make_empty_term(act_state->invisible);
+		} else if (!strcmp(s, "kgt:visible")) {
+			act_state->invisible = 0;
+
+			@t = ast_make_empty_term(act_state->invisible);
+		} else {
+			@t = ast_make_prose_term(act_state->invisible, s);
+		}
 	@};
 
 	<make-group-term>: (a :ast_alt) -> (t :ast_term) = @{
-		@t = ast_make_group_term(@a);
+		@t = ast_make_group_term(act_state->invisible, @a);
 	@};
 
 	<make-range-term>: (m :char, n :char) -> (t :ast_term) = @{
@@ -639,19 +650,19 @@
 			struct ast_alt *new;
 			struct ast_term *t;
 
-			t = ast_make_char_term(i);
-			new = ast_make_alt(t);
+			t = ast_make_char_term(act_state->invisible, i);
+			new = ast_make_alt(act_state->invisible, t);
 
 			new->next = a;
 			a = new;
 		}
 
-		@t = ast_make_group_term(a);
+		@t = ast_make_group_term(act_state->invisible, a);
 	@};
 
 
 	<make-alt>: (t :ast_term) -> (a :ast_alt) = @{
-		@a = ast_make_alt(@t);
+		@a = ast_make_alt(act_state->invisible, @t);
 	@};
 
 	<make-rule>: (n :string, a :ast_alt) -> (r :ast_rule) = @{
@@ -791,6 +802,8 @@
 
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
+
+		act_state->invisible = 0;
 
 		ADVANCE_LEXER;
 		FORM_ENTRY(lex_state, act_state, &g);

--- a/src/rbnf/io.h
+++ b/src/rbnf/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define rbnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
+#define rbnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 struct ast_rule *
 rbnf_input(int (*f)(void *opaque), void *opaque);

--- a/src/rbnf/output.c
+++ b/src/rbnf/output.c
@@ -64,6 +64,9 @@ output_term(const struct ast_term *term)
 		{ 0, 0, " [", " ... ] " }
 	};
 
+	assert(term != NULL);
+	assert(!term->invisible);
+
 	s = NULL;
 	e = NULL;
 
@@ -120,6 +123,9 @@ static void
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
+
+	assert(alt != NULL);
+	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		output_term(term);

--- a/src/rbnf/parser.c
+++ b/src/rbnf/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 102 "src/parser.act"
+#line 103 "src/parser.act"
 
 
 	#include <assert.h>
@@ -65,6 +65,7 @@
 	struct act_state {
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
+		int invisible;
 	};
 
 	struct lex_state {
@@ -286,7 +287,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 290 "src/rbnf/parser.c"
+#line 291 "src/rbnf/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -336,11 +337,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 344 "src/rbnf/parser.c"
+#line 345 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -361,7 +362,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: rep-zero-or-more */
 						{
-#line 533 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
@@ -370,7 +371,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 374 "src/rbnf/parser.c"
+#line 375 "src/rbnf/parser.c"
 						}
 						/* END OF ACTION: rep-zero-or-more */
 					}
@@ -379,7 +380,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 					{
 						/* BEGINNING OF ACTION: rep-zero-or-one */
 						{
-#line 542 "src/parser.act"
+#line 543 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
@@ -388,7 +389,7 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 392 "src/rbnf/parser.c"
+#line 393 "src/rbnf/parser.c"
 						}
 						/* END OF ACTION: rep-zero-or-one */
 					}
@@ -408,23 +409,23 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 416 "src/rbnf/parser.c"
+#line 417 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 428 "src/rbnf/parser.c"
+#line 429 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -545,21 +546,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 662 "src/parser.act"
+#line 673 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 553 "src/rbnf/parser.c"
+#line 554 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 709 "src/parser.act"
+#line 720 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 563 "src/rbnf/parser.c"
+#line 564 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -583,13 +584,13 @@ ZL2_body:;
 					case (TOK_CHAR):
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 340 "src/parser.act"
+#line 341 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 593 "src/rbnf/parser.c"
+#line 594 "src/rbnf/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						break;
@@ -602,12 +603,12 @@ ZL2_body:;
 			/* END OF INLINE: 70 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 519 "src/parser.act"
+#line 520 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 611 "src/rbnf/parser.c"
+#line 612 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -642,11 +643,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		case (TOK_NAME):
 			/* BEGINNING OF EXTRACT: NAME */
 			{
-#line 367 "src/parser.act"
+#line 368 "src/parser.act"
 
 		ZIs = pattern_buffer(lex_state);
 	
-#line 650 "src/rbnf/parser.c"
+#line 651 "src/rbnf/parser.c"
 			}
 			/* END OF EXTRACT: NAME */
 			break;
@@ -659,7 +660,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: make-rule-term */
 		{
-#line 590 "src/parser.act"
+#line 591 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -675,9 +676,9 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 
-		(ZIt) = ast_make_rule_term(r);
+		(ZIt) = ast_make_rule_term(act_state->invisible, r);
 	
-#line 681 "src/rbnf/parser.c"
+#line 682 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: make-rule-term */
 	}
@@ -706,11 +707,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_NAME):
 			/* BEGINNING OF EXTRACT: NAME */
 			{
-#line 367 "src/parser.act"
+#line 368 "src/parser.act"
 
 		ZIs = pattern_buffer(lex_state);
 	
-#line 714 "src/rbnf/parser.c"
+#line 715 "src/rbnf/parser.c"
 			}
 			/* END OF EXTRACT: NAME */
 			break;
@@ -737,11 +738,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 721 "src/parser.act"
+#line 732 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 745 "src/rbnf/parser.c"
+#line 746 "src/rbnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
@@ -755,11 +756,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 658 "src/parser.act"
+#line 669 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 763 "src/rbnf/parser.c"
+#line 764 "src/rbnf/parser.c"
 		}
 		/* END OF ACTION: make-rule */
 		/* BEGINNING OF INLINE: 85 */
@@ -783,11 +784,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 717 "src/parser.act"
+#line 728 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 791 "src/rbnf/parser.c"
+#line 792 "src/rbnf/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
@@ -818,7 +819,7 @@ prod_91(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 677 "src/parser.act"
+#line 688 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -830,7 +831,7 @@ prod_91(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 834 "src/rbnf/parser.c"
+#line 835 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -872,11 +873,11 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 713 "src/parser.act"
+#line 724 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 880 "src/rbnf/parser.c"
+#line 881 "src/rbnf/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
@@ -890,21 +891,21 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 898 "src/rbnf/parser.c"
+#line 899 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 672 "src/parser.act"
+#line 683 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 908 "src/rbnf/parser.c"
+#line 909 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -913,11 +914,11 @@ prod_92(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 921 "src/rbnf/parser.c"
+#line 922 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -948,12 +949,12 @@ prod_93(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 667 "src/parser.act"
+#line 678 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 957 "src/rbnf/parser.c"
+#line 958 "src/rbnf/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -971,7 +972,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 856 "src/parser.act"
+#line 869 "src/parser.act"
 
 
 	static int
@@ -1040,6 +1041,8 @@ ZL1:;
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
 
+		act_state->invisible = 0;
+
 		ADVANCE_LEXER;
 		FORM_ENTRY(lex_state, act_state, &g);
 
@@ -1101,6 +1104,6 @@ ZL1:;
 		return g;
 	}
 
-#line 1105 "src/rbnf/parser.c"
+#line 1108 "src/rbnf/parser.c"
 
 /* END OF FILE */

--- a/src/rbnf/parser.h
+++ b/src/rbnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 315 "src/parser.act"
+#line 316 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_rbnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 858 "src/parser.act"
+#line 871 "src/parser.act"
 
 
 #line 31 "src/rbnf/parser.h"

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -12,5 +12,8 @@ struct ast_rule;
 void
 rewrite_ci_literals(struct ast_rule *g);
 
+void
+rewrite_invisible(struct ast_rule *g);
+
 #endif
 

--- a/src/rewrite_ci.c
+++ b/src/rewrite_ci.c
@@ -24,7 +24,7 @@ static int
 walk_alts(struct ast_alt *alts);
 
 static void
-add_alt(struct ast_alt **alt, const struct txt *t)
+add_alt(int invisible, struct ast_alt **alt, const struct txt *t)
 {
 	struct ast_term *term;
 	struct ast_alt *new;
@@ -37,15 +37,15 @@ add_alt(struct ast_alt **alt, const struct txt *t)
 	/* TODO: move ownership to ast_make_*() and no need to make a new struct txt here */
 	q = xtxtdup(t);
 
-	term = ast_make_literal_term(&q, 0);
+	term = ast_make_literal_term(invisible, &q, 0);
 
-	new = ast_make_alt(term);
+	new = ast_make_alt(invisible, term);
 	new->next = *alt;
 	*alt = new;
 }
 
 static void
-permute_cases(struct ast_alt **alt, const struct txt *t)
+permute_cases(int invisible, struct ast_alt **alt, const struct txt *t)
 {
 	size_t i, j;
 	unsigned long num_alphas, perm_count;
@@ -85,7 +85,7 @@ permute_cases(struct ast_alt **alt, const struct txt *t)
 				: toupper((unsigned char) p[alpha_inds[j]]);
 		}
 		
-		add_alt(alt, t);
+		add_alt(invisible, alt, t);
 	}
 }
 
@@ -113,7 +113,8 @@ rewrite_ci(struct ast_term *term)
 	term->type = TYPE_GROUP;
 	term->u.group = NULL;
 
-	permute_cases(&term->u.group, &tmp);
+	/* invisibility of new alts is inherited from term->invisible itself */
+	permute_cases(term->invisible, &term->u.group, &tmp);
 
 	free((void *) tmp.p);
 }

--- a/src/rewrite_invisible.c
+++ b/src/rewrite_invisible.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+/*
+ * AST node rewriting
+ * (In this case not so much rewriting, but rather just plain removing;
+ * invisible nodes have no semantic effect.)
+ */
+
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "txt.h"
+#include "ast.h"
+#include "rewrite.h"
+#include "xalloc.h"
+
+static void
+walk_alts(struct ast_alt **alts);
+
+static void
+walk_term(struct ast_term *term)
+{
+	assert(term != NULL);
+
+	switch (term->type) {
+	case TYPE_EMPTY:
+	case TYPE_CS_LITERAL:
+	case TYPE_TOKEN:
+	case TYPE_RULE:
+	case TYPE_PROSE:
+	case TYPE_CI_LITERAL:
+		break;
+
+	case TYPE_GROUP:
+		walk_alts(&term->u.group);
+		break;
+	}
+}
+
+static void
+walk_alts(struct ast_alt **alts)
+{
+	struct ast_alt **alt, **next_alt;
+	struct ast_term **term, **next_term;
+
+	assert(alts != NULL);
+
+	for (alt = alts; *alt != NULL; alt = next_alt) {
+		next_alt = &(*alt)->next;
+
+		if ((*alt)->invisible) {
+			struct ast_alt *dead;
+
+			dead = *alt;
+			*alt = (*alt)->next;
+
+			dead->next = NULL;
+			ast_free_alt(dead);
+
+			next_alt = alt;
+			continue;
+		}
+
+		for (term = &(*alt)->terms; *term != NULL; term = next_term) {
+			next_term = &(*term)->next;
+
+			if ((*term)->invisible) {
+				struct ast_term *dead;
+
+				dead = *term;
+				*term = (*term)->next;
+
+				dead->next = NULL;
+				ast_free_term(dead);
+
+				next_term = term;
+				continue;
+			}
+
+			walk_term(*term);
+		}
+	}
+}
+
+void
+rewrite_invisible(struct ast_rule *grammar)
+{
+	struct ast_rule *rule;
+
+	for (rule = grammar; rule != NULL; rule = rule->next) {
+		walk_alts(&rule->alts);
+	}
+}
+

--- a/src/rrd/node.c
+++ b/src/rrd/node.c
@@ -60,7 +60,7 @@ node_free(struct node *n)
 }
 
 struct node *
-node_create_ci_literal(const struct txt *literal)
+node_create_ci_literal(int invisible, const struct txt *literal)
 {
 	struct node *new;
 
@@ -70,13 +70,15 @@ node_create_ci_literal(const struct txt *literal)
 
 	new->type = NODE_CI_LITERAL;
 
+	new->invisible = invisible;
+
 	new->u.literal = *literal;
 
 	return new;
 }
 
 struct node *
-node_create_cs_literal(const struct txt *literal)
+node_create_cs_literal(int invisible, const struct txt *literal)
 {
 	struct node *new;
 
@@ -86,13 +88,15 @@ node_create_cs_literal(const struct txt *literal)
 
 	new->type = NODE_CS_LITERAL;
 
+	new->invisible = invisible;
+
 	new->u.literal = *literal;
 
 	return new;
 }
 
 struct node *
-node_create_name(const char *name)
+node_create_name(int invisible, const char *name)
 {
 	struct node *new;
 
@@ -102,13 +106,15 @@ node_create_name(const char *name)
 
 	new->type = NODE_RULE;
 
+	new->invisible = invisible;
+
 	new->u.name = name;
 
 	return new;
 }
 
 struct node *
-node_create_prose(const char *prose)
+node_create_prose(int invisible, const char *prose)
 {
 	struct node *new;
 
@@ -118,13 +124,15 @@ node_create_prose(const char *prose)
 
 	new->type = NODE_PROSE;
 
+	new->invisible = invisible;
+
 	new->u.prose = prose;
 
 	return new;
 }
 
 struct node *
-node_create_alt(struct list *alt)
+node_create_alt(int invisible, struct list *alt)
 {
 	struct node *new;
 
@@ -132,13 +140,15 @@ node_create_alt(struct list *alt)
 
 	new->type = NODE_ALT;
 
+	new->invisible = invisible;
+
 	new->u.alt = alt;
 
 	return new;
 }
 
 struct node *
-node_create_alt_skippable(struct list *alt)
+node_create_alt_skippable(int invisible, struct list *alt)
 {
 	struct node *new;
 
@@ -146,13 +156,15 @@ node_create_alt_skippable(struct list *alt)
 
 	new->type = NODE_ALT_SKIPPABLE;
 
+	new->invisible = invisible;
+
 	new->u.alt = alt;
 
 	return new;
 }
 
 struct node *
-node_create_seq(struct list *seq)
+node_create_seq(int invisible, struct list *seq)
 {
 	struct node *new;
 
@@ -160,19 +172,23 @@ node_create_seq(struct list *seq)
 
 	new->type = NODE_SEQ;
 
+	new->invisible = invisible;
+
 	new->u.seq = seq;
 
 	return new;
 }
 
 struct node *
-node_create_loop(struct node *forward, struct node *backward)
+node_create_loop(int invisible, struct node *forward, struct node *backward)
 {
 	struct node *new;
 
 	new = xmalloc(sizeof *new);
 
 	new->type = NODE_LOOP;
+
+	new->invisible = invisible;
 
 	new->u.loop.forward  = forward;
 	new->u.loop.backward = backward;
@@ -184,7 +200,7 @@ node_create_loop(struct node *forward, struct node *backward)
 }
 
 void
-node_make_seq(struct node **n)
+node_make_seq(int invisible, struct node **n)
 {
 	struct list *new;
 
@@ -198,7 +214,7 @@ node_make_seq(struct node **n)
 
 	list_push(&new, *n);
 
-	*n = node_create_seq(new);
+	*n = node_create_seq(invisible, new);
 }
 
 int
@@ -213,6 +229,10 @@ node_compare(const struct node *a, const struct node *b)
 	}
 
 	if (a->type != b->type) {
+		return 0;
+	}
+
+	if (a->invisible != b->invisible) {
 		return 0;
 	}
 

--- a/src/rrd/node.h
+++ b/src/rrd/node.h
@@ -23,6 +23,8 @@ struct node {
 		NODE_LOOP
 	} type;
 
+	int invisible;
+
 	union {
 		struct txt literal; /* TODO: point to ast_literal instead */
 		const char *name;   /* TODO: point to ast_rule instead */
@@ -44,31 +46,31 @@ void
 node_free(struct node *);
 
 struct node *
-node_create_ci_literal(const struct txt *literal);
+node_create_ci_literal(int invisible, const struct txt *literal);
 
 struct node *
-node_create_cs_literal(const struct txt *literal);
+node_create_cs_literal(int invisible, const struct txt *literal);
 
 struct node *
-node_create_name(const char *name);
+node_create_name(int invisible, const char *name);
 
 struct node *
-node_create_prose(const char *name);
+node_create_prose(int invisible, const char *name);
 
 struct node *
-node_create_alt(struct list *alt);
+node_create_alt(int invisible, struct list *alt);
 
 struct node *
-node_create_alt_skippable(struct list *alt);
+node_create_alt_skippable(int invisible, struct list *alt);
 
 struct node *
-node_create_seq(struct list *seq);
+node_create_seq(int invisible, struct list *seq);
 
 struct node *
-node_create_loop(struct node *forward, struct node *backward);
+node_create_loop(int invisible, struct node *forward, struct node *backward);
 
 void
-node_make_seq(struct node **n);
+node_make_seq(int invisible, struct node **n);
 
 int
 node_compare(const struct node *a, const struct node *b);

--- a/src/rrd/pretty_affix.c
+++ b/src/rrd/pretty_affix.c
@@ -76,14 +76,14 @@ collapse_suffix(int *changed, struct list **head, struct node *loop)
 	assert(loop->type == NODE_LOOP);
 
 	/* if loop .forward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.forward);
+	node_make_seq(loop->invisible, &loop->u.loop.forward);
 
 	assert(loop->u.loop.forward != NULL);
 	assert(loop->u.loop.forward->type == NODE_SEQ);
 	assert(loop->u.loop.forward->u.seq != NULL);
 
 	/* if loop .backward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.backward);
+	node_make_seq(loop->invisible, &loop->u.loop.backward);
 
 	assert(loop->u.loop.backward != NULL);
 	assert(loop->u.loop.backward->type == NODE_SEQ);
@@ -116,14 +116,14 @@ collapse_prefix(int *changed, struct list **head, struct node *loop)
 	assert(loop->type == NODE_LOOP);
 
 	/* if loop .forward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.forward);
+	node_make_seq(loop->invisible, &loop->u.loop.forward);
 
 	assert(loop->u.loop.forward != NULL);
 	assert(loop->u.loop.forward->type == NODE_SEQ);
 	assert(loop->u.loop.forward->u.seq != NULL);
 
 	/* if loop .backward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.backward);
+	node_make_seq(loop->invisible, &loop->u.loop.backward);
 
 	assert(loop->u.loop.backward != NULL);
 	assert(loop->u.loop.backward->type == NODE_SEQ);

--- a/src/rrd/pretty_bottom.c
+++ b/src/rrd/pretty_bottom.c
@@ -64,7 +64,7 @@ bottom_loop(struct node **np)
 		list_push(&new, n);
 		list_push(&new, NULL);
 
-		*np = node_create_alt(new);
+		*np = node_create_alt(n->invisible, new);
 	}
 
 	return 1;

--- a/src/rrd/pretty_ci.c
+++ b/src/rrd/pretty_ci.c
@@ -77,7 +77,7 @@ ci_alt(int *changed, struct node *n)
 
 			t = xtxtdup(&p->node->u.literal);
 			* (char *) t.p = toupper((unsigned char) *t.p);
-			new = node_create_cs_literal(&t);
+			new = node_create_cs_literal(p->node->invisible, &t);
 			list_push(&list, new);
 
 			*changed = 1;

--- a/src/rrd/pretty_roll.c
+++ b/src/rrd/pretty_roll.c
@@ -42,7 +42,7 @@ roll_prefix(int *changed, struct list **entry, struct node *loop)
 	p = entry;
 
 	/* if loop .backward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.backward);
+	node_make_seq(loop->invisible, &loop->u.loop.backward);
 
 	assert(loop->u.loop.backward != NULL);
 	assert(loop->u.loop.backward->type == NODE_SEQ);
@@ -58,7 +58,7 @@ roll_prefix(int *changed, struct list **entry, struct node *loop)
 	}
 
 	/* if loop .forward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.forward);
+	node_make_seq(loop->invisible, &loop->u.loop.forward);
 
 	assert(loop->u.loop.forward != NULL);
 	assert(loop->u.loop.forward->type == NODE_SEQ);
@@ -123,7 +123,7 @@ roll_suffix(int *changed, struct list **exit, struct node *loop)
 	p = exit;
 
 	/* if loop .backward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.backward);
+	node_make_seq(loop->invisible, &loop->u.loop.backward);
 
 	assert(loop->u.loop.backward != NULL);
 	assert(loop->u.loop.backward->type == NODE_SEQ);
@@ -139,7 +139,7 @@ roll_suffix(int *changed, struct list **exit, struct node *loop)
 	}
 
 	/* if loop .forward isn't a NODE_SEQ, make it one */
-	node_make_seq(&loop->u.loop.forward);
+	node_make_seq(loop->invisible, &loop->u.loop.forward);
 
 	assert(loop->u.loop.forward != NULL);
 	assert(loop->u.loop.forward->type == NODE_SEQ);

--- a/src/rrd/rewrite_ci.c
+++ b/src/rrd/rewrite_ci.c
@@ -25,7 +25,7 @@
 #include "../rrd/list.h"
 
 static void
-add_alt(struct list **list, const struct txt *t)
+add_alt(int invisible, struct list **list, const struct txt *t)
 {
 	struct node *node;
 	struct txt q;
@@ -36,14 +36,14 @@ add_alt(struct list **list, const struct txt *t)
 
 	q = xtxtdup(t);
 
-	node = node_create_cs_literal(&q);
+	node = node_create_cs_literal(invisible, &q);
 
 	list_push(list, node);
 }
 
 /* TODO: centralise */
 static void
-permute_cases(struct list **list, const struct txt *t)
+permute_cases(int invisible, struct list **list, const struct txt *t)
 {
 	size_t i, j;
 	unsigned long num_alphas, perm_count;
@@ -84,7 +84,7 @@ permute_cases(struct list **list, const struct txt *t)
 				: toupper((unsigned char) p[alpha_inds[j]]);
 		}
 
-		add_alt(list, t);
+		add_alt(invisible, list, t);
 	}
 }
 
@@ -112,7 +112,8 @@ rewrite_ci(struct node *n)
 	n->type = NODE_ALT;
 	n->u.alt = NULL;
 
-	permute_cases(&n->u.alt, &tmp);
+	/* invisibility of new alts is inherited from n->invisible itself */
+	permute_cases(n->invisible, &n->u.alt, &tmp);
 
 	free((void *) tmp.p);
 }

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -113,7 +113,6 @@ tnode_free(struct tnode *n)
 	}
 
 	switch (n->type) {
-	case TNODE_SKIP:
 	case TNODE_RTL_ARROW:
 	case TNODE_LTR_ARROW:
 	case TNODE_ELLIPSIS:
@@ -493,10 +492,15 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 	new = xmalloc(sizeof *new);
 
 	if (node == NULL) {
-		new->type = TNODE_SKIP;
+		new->type = TNODE_VLIST;
 		new->w = 0;
 		new->a = 0;
 		new->d = 1;
+
+		new->u.vlist.n = 0;
+		new->u.vlist.o = 0;
+		new->u.vlist.a = NULL;
+		new->u.vlist.b = NULL;
 
 		return new;
 	}
@@ -584,7 +588,7 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 			if (node->type == NODE_ALT_SKIPPABLE) {
 				assert(new->u.vlist.n > i);
 				assert(new->u.vlist.a[i] != NULL);
-				assert(new->u.vlist.a[i]->type == TNODE_SKIP);
+				assert(new->u.vlist.a[i]->type == TNODE_VLIST && new->u.vlist.a[i]->u.vlist.n == 0);
 				assert(new->u.vlist.a[i]->a + new->u.vlist.a[i]->d == 1);
 
 				/* arrows are more helpful here */
@@ -721,7 +725,7 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 		new->u.vlist.b[0] = rtl ? TLINE_H : TLINE_h;
 		new->u.vlist.b[1] = TLINE_E;
 
-		if (new->u.vlist.a[1]->type == TNODE_SKIP) {
+		if (new->u.vlist.a[1]->type == TNODE_VLIST && new->u.vlist.a[1]->u.vlist.n == 0) {
 			/* arrows are helpful when going backwards */
 			new->u.vlist.a[1]->type = !rtl ? TNODE_RTL_ARROW : TNODE_LTR_ARROW;
 			new->u.vlist.a[1]->w = 1;

--- a/src/rrd/tnode.c
+++ b/src/rrd/tnode.c
@@ -235,6 +235,10 @@ tnode_create_alt_list(const struct list *list, int rtl, const struct dim *dim)
 	i = 0;
 	p = list;
 
+/* TODO: how to handle invisible alts? have the corner tiles hidden?
+at the moment we render an empty line, which makes sense in seqs but not in alts
+*/
+
 	while (p != NULL) {
 		unsigned char c;
 
@@ -799,6 +803,33 @@ tnode_create_node(const struct node *node, int rtl, const struct dim *dim)
 		}
 
 		break;
+	}
+
+/* TODO:
+we make a tnode subtree above, and then if it is invisible, replace the entire thing
+with a regular skip or arrow or whatever
+TODO: option to show invisible nodes
+
+we do this after constructing the node in order to find its width
+*/
+	if (node->invisible) {
+		struct tnode *old;
+
+		old = new;
+
+		new = xmalloc(sizeof *new);
+
+		new->type = TNODE_VLIST;
+		new->w = old->w;
+		new->a = old->a;
+		new->d = old->d;
+
+		new->u.vlist.n = 0;
+		new->u.vlist.o = 0;
+		new->u.vlist.a = NULL;
+		new->u.vlist.b = NULL;
+
+		tnode_free(old);
 	}
 
 	return new;

--- a/src/rrd/tnode.h
+++ b/src/rrd/tnode.h
@@ -59,7 +59,6 @@ struct tnode_hlist {
 
 struct tnode {
 	enum {
-		TNODE_SKIP,
 		TNODE_RTL_ARROW,
 		TNODE_LTR_ARROW,
 		TNODE_ELLIPSIS,

--- a/src/rrd/transform.c
+++ b/src/rrd/transform.c
@@ -46,7 +46,7 @@ transform_terms(const struct ast_alt *alt, struct node **r)
 		tail = &(*tail)->next;
 	}
 
-	*r = node_create_seq(list);
+	*r = node_create_seq(alt->invisible, list);
 
 	return 1;
 
@@ -79,7 +79,7 @@ transform_alts(const struct ast_alt *alts, struct node **r)
 		tail = &(*tail)->next;
 	}
 
-	*r = node_create_alt(list);
+	*r = node_create_alt(alts->invisible, list);
 
 	return 1;
 
@@ -101,24 +101,24 @@ single_term(const struct ast_term *term, struct node **r)
 		return 1;
 
 	case TYPE_RULE:
-		*r = node_create_name(term->u.rule->name);
+		*r = node_create_name(term->invisible, term->u.rule->name);
 		return 1;
 
 	case TYPE_CI_LITERAL:
 		/* can't create a sequence of alts; the tokenisation would be wrong */
-		*r = node_create_ci_literal(&term->u.literal);
+		*r = node_create_ci_literal(term->invisible, &term->u.literal);
 		return 1;
 
 	case TYPE_CS_LITERAL:
-		*r = node_create_cs_literal(&term->u.literal);
+		*r = node_create_cs_literal(term->invisible, &term->u.literal);
 		return 1;
 
 	case TYPE_TOKEN:
-		*r = node_create_name(term->u.token);
+		*r = node_create_name(term->invisible, term->u.token);
 		return 1;
 
 	case TYPE_PROSE:
-		*r = node_create_prose(term->u.prose);
+		*r = node_create_prose(term->invisible, term->u.prose);
 		return 1;
 
 	case TYPE_GROUP:
@@ -144,7 +144,7 @@ optional_term(const struct ast_term *term, struct node **r)
 
 	list_push(&list, n);
 
-	*r = node_create_alt_skippable(list);
+	*r = node_create_alt_skippable(term->invisible, list);
 
 	return 1;
 }
@@ -160,7 +160,7 @@ oneormore_term(const struct ast_term *term, struct node **r)
 		return 0;
 	}
 
-	*r = node_create_loop(n, NULL);
+	*r = node_create_loop(term->invisible, n, NULL);
 
 	return 1;
 }
@@ -176,7 +176,7 @@ zeroormore_term(const struct ast_term *term, struct node **r)
 		return 0;
 	}
 
-	*r = node_create_loop(NULL, n);
+	*r = node_create_loop(term->invisible, NULL, n);
 
 	return 1;
 }
@@ -195,11 +195,11 @@ finite_term(const struct ast_term *term, struct node **r)
 	}
 
 	if (term->min > 0) {
-		loop = node_create_loop(n, NULL);
+		loop = node_create_loop(term->invisible, n, NULL);
 		loop->u.loop.min = term->min - 1;
 		loop->u.loop.max = term->max - 1;
 	} else {
-		loop = node_create_loop(NULL, n);
+		loop = node_create_loop(term->invisible, NULL, n);
 		loop->u.loop.min = term->min;
 		loop->u.loop.max = term->max;
 	}
@@ -220,7 +220,7 @@ atleast_term(const struct ast_term *term, struct node **r)
 		return 0;
 	}
 
-	*r = node_create_loop(NULL, n);
+	*r = node_create_loop(term->invisible, NULL, n);
 
 	(*r)->u.loop.min = term->min;
 

--- a/src/rrdot/output.c
+++ b/src/rrdot/output.c
@@ -124,22 +124,31 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 		break;
 	}
 
-	printf("\t\"%s/%p\"%s -> \"%s/%p\";\n",
+	printf("\t\"%s/%p\"%s -> \"%s/%p\"",
 		prefix, parent, port,
 		prefix, (void *) node);
+	if (node->invisible) {
+		printf(" [ color = blue, style = dashed ]");
+	}
+	printf(";\n");
 
 	printf("\t\"%s/%p\" [ ",
 		prefix, (void *) node);
+	if (node->invisible) {
+		printf("color = blue, fontcolor = blue, fillcolor = aliceblue, style = \"rounded,dashed\", ");
+	}
 
 	switch (node->type) {
 	case NODE_CI_LITERAL:
-		printf("style = filled, shape = box, label = \"\\\"");
+		printf("style = \"%s\", shape = box, label = \"\\\"",
+			node->invisible ? "filled,dashed" : "filled");
 		escputt(&node->u.literal, stdout);
 		printf("\\\"\"/i");
 		break;
 
 	case NODE_CS_LITERAL:
-		printf("style = filled, shape = box, label = \"\\\"");
+		printf("style = \"%s\", shape = box, label = \"\\\"",
+			node->invisible ? "filled,dashed" : "filled");
 		escputt(&node->u.literal, stdout);
 		printf("\\\"\"");
 		break;

--- a/src/rrdump/output.c
+++ b/src/rrdump/output.c
@@ -50,32 +50,42 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 	case NODE_CI_LITERAL:
 		print_indent(f, depth);
-		fprintf(f, "LITERAL: \"%.*s\"/i\n", (int) n->u.literal.n, n->u.literal.p);
+		fprintf(f, "LITERAL%s: \"%.*s\"/i\n",
+			n->invisible ? " (invisible)" : "",
+			(int) n->u.literal.n, n->u.literal.p);
 
 		break;
 
 	case NODE_CS_LITERAL:
 		print_indent(f, depth);
-		fprintf(f, "LITERAL: \"%.*s\"\n", (int) n->u.literal.n, n->u.literal.p);
+		fprintf(f, "LITERAL%s: \"%.*s\"\n",
+			n->invisible ? " (invisible)" : "",
+			(int) n->u.literal.n, n->u.literal.p);
 
 		break;
 
 	case NODE_RULE:
 		print_indent(f, depth);
-		fprintf(f, "NAME: <%s>\n", n->u.name);
+		fprintf(f, "NAME%s: <%s>\n",
+			n->invisible ? " (invisible)" : "",
+			n->u.name);
 
 		break;
 
 	case NODE_PROSE:
 		print_indent(f, depth);
-		fprintf(f, "PROSE: ?%s?\n", n->u.prose);
+		fprintf(f, "PROSE%s: ?%s?\n",
+			n->invisible ? " (invisible)" : "",
+			n->u.prose);
 
 		break;
 
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
 		print_indent(f, depth);
-		fprintf(f, "%s: [\n", n->type == NODE_ALT ? "ALT" : "ALT|SKIP");
+		fprintf(f, "%s%s: [\n",
+			n->invisible ? " (invisible)" : "",
+			n->type == NODE_ALT ? "ALT" : "ALT|SKIP");
 		for (p = n->u.alt; p != NULL; p = p->next) {
 			node_walk(f, p->node, depth + 1);
 		}
@@ -86,7 +96,8 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 	case NODE_SEQ:
 		print_indent(f, depth);
-		fprintf(f, "SEQ: [\n");
+		fprintf(f, "SEQ%s: [\n",
+			n->invisible ? " (invisible)" : "");
 		for (p = n->u.seq; p != NULL; p = p->next) {
 			node_walk(f, p->node, depth + 1);
 		}
@@ -97,7 +108,8 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 	case NODE_LOOP:
 		print_indent(f, depth);
-		fprintf(f, "LOOP:\n");
+		fprintf(f, "LOOP%s:\n",
+			n->invisible ? " (invisible)" : "");
 
 		if (n->u.loop.forward != NULL) {
 			print_indent(f, depth + 1);

--- a/src/rrll/io.h
+++ b/src/rrll/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define rrll_ast_unsupported FEATURE_AST_BINARY
+#define rrll_ast_unsupported (FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 #define rrll_rrd_unsupported FEATURE_RRD_CI_LITERAL
 
 extern int prettify;

--- a/src/rrll/output.c
+++ b/src/rrll/output.c
@@ -142,6 +142,8 @@ node_walk(FILE *f, const struct node *n)
 		return;
 	}
 
+	assert(!n->invisible);
+
 	switch (n->type) {
 		const struct list *p;
 

--- a/src/rrparcon/io.h
+++ b/src/rrparcon/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define rrparcon_ast_unsupported FEATURE_AST_BINARY
+#define rrparcon_ast_unsupported (FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 #define rrparcon_rrd_unsupported FEATURE_RRD_CI_LITERAL
 
 extern int prettify;

--- a/src/rrparcon/output.c
+++ b/src/rrparcon/output.c
@@ -153,6 +153,8 @@ node_walk(FILE *f, const struct node *n, int depth)
 		return;
 	}
 
+	assert(!n->invisible);
+
 	switch (n->type) {
 		const struct list *p;
 

--- a/src/rrta/io.h
+++ b/src/rrta/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define rrta_ast_unsupported FEATURE_AST_BINARY
+#define rrta_ast_unsupported (FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 #define rrta_rrd_unsupported FEATURE_RRD_CI_LITERAL
 
 extern int prettify;

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -50,14 +50,6 @@ tnode_walk(FILE *f, const struct tnode *n, int depth)
 	switch (n->type) {
 		size_t i;
 
-	case TNODE_SKIP:
-		print_indent(f, depth);
-		fprintf(f, "SKIP");
-		print_coords(f, n);
-		fprintf(f, "\n");
-
-		break;
-
 	case TNODE_RTL_ARROW:
 		print_indent(f, depth);
 		fprintf(f, "RTL_ARROW");

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -360,9 +360,6 @@ node_walk_render(const struct tnode *n, struct render_context *ctx)
 	assert(ctx != NULL);
 
 	switch (n->type) {
-	case TNODE_SKIP:
-		break;
-
 	case TNODE_RTL_ARROW:
 		bprintf(ctx, "%.*s", (int) n->w, "<");
 		break;

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -256,7 +256,17 @@ render_vlist(const struct tnode *n, struct render_context *ctx)
 		ctx->y -= n->a;
 	}
 
-	for (j = 0; j < n->u.vlist.n; j++) {
+	/*
+	 * A vlist of 0 items is a special case, meaning to draw
+	 * a horizontal line only.
+	 */
+	if (n->u.vlist.n == 0) {
+		size_t i;
+
+		for (i = 0; i < n->w; i++) {
+			bprintf(ctx, "\022");
+		}
+	} else for (j = 0; j < n->u.vlist.n; j++) {
 		ctx->x = x;
 
 		render_tline(ctx, n->u.vlist.b[j], 0);

--- a/src/sid/io.h
+++ b/src/sid/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define sid_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
+#define sid_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 void
 sid_output(const struct ast_rule *grammar);

--- a/src/sid/output.c
+++ b/src/sid/output.c
@@ -46,6 +46,9 @@ output_literal(const struct txt *t)
 static void
 output_basic(const struct ast_term *term)
 {
+	assert(term != NULL);
+	assert(!term->invisible);
+
 	switch (term->type) {
 	case TYPE_EMPTY:
 		fputs("$$; ", stdout);
@@ -81,6 +84,9 @@ output_basic(const struct ast_term *term)
 static void
 output_term(const struct ast_term *term)
 {
+	assert(term != NULL);
+	assert(!term->invisible);
+
 	/* SID cannot express term repetition; TODO: semantic checks for this */
 	/* TODO: can output repetition as [ ... ] local rules with a stub to call them X times? */
 	assert(term->min <= 1);
@@ -101,6 +107,9 @@ static void
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
+
+	assert(alt != NULL);
+	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		output_term(term);
@@ -164,7 +173,13 @@ output_terminals(const struct ast_rule *grammar)
 			const struct ast_term *term;
 			struct ast_term *t;
 
+			assert(alt!= NULL);
+			assert(!alt->invisible);
+
 			for (term = alt->terms; term != NULL; term = term->next) {
+				assert(term!= NULL);
+				assert(!term->invisible);
+
 				switch (term->type) {
 				case TYPE_EMPTY:
 				case TYPE_GROUP:
@@ -193,6 +208,7 @@ output_terminals(const struct ast_rule *grammar)
 				t = xmalloc(sizeof *t);
 				t->u.literal = term->u.literal;
 				t->type = term->type;
+				t->invisible = 0;
 				t->next = found;
 				found = t;
 			}

--- a/src/svg/output.c
+++ b/src/svg/output.c
@@ -481,11 +481,6 @@ node_walk_render(const struct tnode *n,
 	assert(ctx != NULL);
 
 	switch (n->type) {
-	case TNODE_SKIP:
-		/* TODO: skips under loop alts are too close to the line */
-		ctx->x += n->w * 10;
-		break;
-
 	case TNODE_RTL_ARROW:
 		svg_path_h(&ctx->paths, ctx->x, ctx->y, 10);
 		svg_arrow(ctx, ctx->x + n->w * 5, ctx->y, 1);
@@ -525,7 +520,7 @@ node_walk_render(const struct tnode *n,
 		if (n->u.comment.tnode->type == TNODE_VLIST
 		&& n->u.comment.tnode->u.vlist.o == 0
 		&& n->u.comment.tnode->u.vlist.n == 2
-		&& (n->u.comment.tnode->u.vlist.a[1]->type == TNODE_SKIP || n->u.comment.tnode->u.vlist.a[1]->type == TNODE_RTL_ARROW || n->u.comment.tnode->u.vlist.a[1]->type == TNODE_LTR_ARROW)) {
+		&& ((n->u.comment.tnode->u.vlist.a[1]->type == TNODE_VLIST && n->u.comment.tnode->u.vlist.a[1]->u.vlist.n == 0) || n->u.comment.tnode->u.vlist.a[1]->type == TNODE_RTL_ARROW || n->u.comment.tnode->u.vlist.a[1]->type == TNODE_LTR_ARROW)) {
 			offset += 10;
 		}
 
@@ -563,6 +558,7 @@ node_walk_render(const struct tnode *n,
 	}
 
 	case TNODE_VLIST:
+		/* TODO: .n == 0 skips under loop alts are too close to the line */
 		render_vlist(n, ctx, base);
 		break;
 

--- a/src/svg/output.c
+++ b/src/svg/output.c
@@ -387,7 +387,14 @@ render_vlist(const struct tnode *n,
 	x = ctx->x;
 	y = ctx->y;
 
-	for (j = 0; j < n->u.vlist.n; j++) {
+
+	/*
+	 * A vlist of 0 items is a special case, meaning to draw
+	 * a horizontal line only.
+	 */
+	if (n->u.vlist.n == 0 && n->w > 0) {
+		svg_path_h(&ctx->paths, ctx->x, ctx->y, n->w * 10);
+	} else for (j = 0; j < n->u.vlist.n; j++) {
 		ctx->x = x;
 
 		render_tline_outer(ctx, n->u.vlist.b[j], 0);

--- a/src/wsn/io.h
+++ b/src/wsn/io.h
@@ -9,7 +9,7 @@
 
 struct ast_rule;
 
-#define wsn_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY)
+#define wsn_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 struct ast_rule *
 wsn_input(int (*f)(void *opaque), void *opaque);

--- a/src/wsn/output.c
+++ b/src/wsn/output.c
@@ -40,6 +40,9 @@ output_term(const struct ast_term *term)
 		{ 0, 0, " { ", " }" }
 	};
 
+	assert(term != NULL);
+	assert(!term->invisible);
+
 	s = NULL;
 	e = NULL;
 
@@ -113,6 +116,9 @@ static void
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
+
+	assert(alt != NULL);
+	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
 		output_term(term);

--- a/src/wsn/parser.c
+++ b/src/wsn/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 102 "src/parser.act"
+#line 103 "src/parser.act"
 
 
 	#include <assert.h>
@@ -65,6 +65,7 @@
 	struct act_state {
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
+		int invisible;
 	};
 
 	struct lex_state {
@@ -286,7 +287,7 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 290 "src/wsn/parser.c"
+#line 291 "src/wsn/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -336,11 +337,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 344 "src/wsn/parser.c"
+#line 345 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -365,16 +366,16 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 373 "src/wsn/parser.c"
+#line 374 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 542 "src/parser.act"
+#line 543 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
@@ -383,19 +384,19 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 387 "src/wsn/parser.c"
+#line 388 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 399 "src/wsn/parser.c"
+#line 400 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -420,16 +421,16 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 629 "src/parser.act"
+#line 640 "src/parser.act"
 
-		(ZIt) = ast_make_group_term((ZIa));
+		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 428 "src/wsn/parser.c"
+#line 429 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 533 "src/parser.act"
+#line 534 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
@@ -438,19 +439,19 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 442 "src/wsn/parser.c"
+#line 443 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 551 "src/parser.act"
+#line 552 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 454 "src/wsn/parser.c"
+#line 455 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -568,13 +569,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 340 "src/parser.act"
+#line 341 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 578 "src/wsn/parser.c"
+#line 579 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -584,13 +585,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: ESC */
 						{
-#line 334 "src/parser.act"
+#line 335 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 2);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 594 "src/wsn/parser.c"
+#line 595 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -603,12 +604,12 @@ ZL2_body:;
 			/* END OF INLINE: 73 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 519 "src/parser.act"
+#line 520 "src/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 612 "src/wsn/parser.c"
+#line 613 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
@@ -638,11 +639,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 578 "src/parser.act"
+#line 579 "src/parser.act"
 
-		(ZIt) = ast_make_empty_term();
+		(ZIt) = ast_make_empty_term(act_state->invisible);
 	
-#line 646 "src/wsn/parser.c"
+#line 647 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -653,7 +654,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 353 "src/parser.act"
+#line 354 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -670,13 +671,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 674 "src/wsn/parser.c"
+#line 675 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 590 "src/parser.act"
+#line 591 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -692,9 +693,9 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			goto ZL1;
 		}
 
-		(ZIt) = ast_make_rule_term(r);
+		(ZIt) = ast_make_rule_term(act_state->invisible, r);
 	
-#line 698 "src/wsn/parser.c"
+#line 699 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -708,12 +709,12 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			case (TOK_CS__LITERAL):
 				/* BEGINNING OF EXTRACT: CS_LITERAL */
 				{
-#line 376 "src/parser.act"
+#line 377 "src/parser.act"
 
 		ZIx.p = pattern_buffer(lex_state);
 		ZIx.n = strlen(ZIx.p);
 	
-#line 717 "src/wsn/parser.c"
+#line 718 "src/wsn/parser.c"
 				}
 				/* END OF EXTRACT: CS_LITERAL */
 				break;
@@ -726,11 +727,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 611 "src/parser.act"
+#line 612 "src/parser.act"
 
-		(ZIt) = ast_make_literal_term(&(ZIx), 0);
+		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 0);
 	
-#line 734 "src/wsn/parser.c"
+#line 735 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -764,7 +765,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 353 "src/parser.act"
+#line 354 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -781,7 +782,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 785 "src/wsn/parser.c"
+#line 786 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -805,11 +806,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 721 "src/parser.act"
+#line 732 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 813 "src/wsn/parser.c"
+#line 814 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
@@ -823,11 +824,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 658 "src/parser.act"
+#line 669 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 831 "src/wsn/parser.c"
+#line 832 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-rule */
 		/* BEGINNING OF INLINE: 88 */
@@ -846,11 +847,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 717 "src/parser.act"
+#line 728 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 854 "src/wsn/parser.c"
+#line 855 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
@@ -892,21 +893,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 662 "src/parser.act"
+#line 673 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 900 "src/wsn/parser.c"
+#line 901 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 709 "src/parser.act"
+#line 720 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 910 "src/wsn/parser.c"
+#line 911 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -929,7 +930,7 @@ prod_93(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 677 "src/parser.act"
+#line 688 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
 			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
@@ -941,7 +942,7 @@ prod_93(lex_state lex_state, act_state act_state, map_rule *ZIl)
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIr);
 	
-#line 945 "src/wsn/parser.c"
+#line 946 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-rule-to-list */
 		}
@@ -983,11 +984,11 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 713 "src/parser.act"
+#line 724 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
-#line 991 "src/wsn/parser.c"
+#line 992 "src/wsn/parser.c"
 					}
 					/* END OF ACTION: err-expected-alt */
 				}
@@ -1001,21 +1002,21 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 1009 "src/wsn/parser.c"
+#line 1010 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 672 "src/parser.act"
+#line 683 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
 	
-#line 1019 "src/wsn/parser.c"
+#line 1020 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-alt-to-list */
 		}
@@ -1024,11 +1025,11 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 654 "src/parser.act"
+#line 665 "src/parser.act"
 
-		(ZIl) = ast_make_alt((*ZIt));
+		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
-#line 1032 "src/wsn/parser.c"
+#line 1033 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-alt */
 		}
@@ -1060,12 +1061,12 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 667 "src/parser.act"
+#line 678 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
 	
-#line 1069 "src/wsn/parser.c"
+#line 1070 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: add-term-to-list */
 		}
@@ -1083,7 +1084,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 856 "src/parser.act"
+#line 869 "src/parser.act"
 
 
 	static int
@@ -1152,6 +1153,8 @@ ZL1:;
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
 
+		act_state->invisible = 0;
+
 		ADVANCE_LEXER;
 		FORM_ENTRY(lex_state, act_state, &g);
 
@@ -1213,6 +1216,6 @@ ZL1:;
 		return g;
 	}
 
-#line 1217 "src/wsn/parser.c"
+#line 1220 "src/wsn/parser.c"
 
 /* END OF FILE */

--- a/src/wsn/parser.h
+++ b/src/wsn/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 315 "src/parser.act"
+#line 316 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_wsn(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 858 "src/parser.act"
+#line 871 "src/parser.act"
 
 
 #line 31 "src/wsn/parser.h"


### PR DESCRIPTION
Here I've broken a rule I've had for quite a while with the BNF parsing in kgt — to not implement any non-standard things. I've added an extension for dialects which provide "prose" nodes:
```
initializer = assignment-exp <kgt:invisible> "," <kgt:visible> / "{" initializer-list <kgt:invisible> "," <kgt:visible> "}" / "{" initializer-list "," "}"

initializer-list = *( initializer "," ) initializer

type-name = spec-qualifier-list [ abstract-declarator ]

abstract-declarator = pointer <kgt:invisible> direct-abstract-declarator <kgt:visible> / pointer direct-abstract-declarator / <kgt:invisible> pointer <kgt:visible> direct-abstract-declarator

direct-abstract-declarator = "(" abstract-declarator ")" / [ direct-abstract-declarator ] ("[" const-exp "]" / "[" <kgt:invisible> const-exp <kgt:visible> "]" / "(" [ param-type-list ] ")")
```
Here the `<kgt:invisible>` and `<kgt:visible>` nodes do not themselves appear, but they mark a region where nodes are flagged as invisible. They have no semantic effect on a grammar.

This is quite a compromise, but it's the best I can think of. Other suggestions welcome.

These invisible nodes are elided when rendering out to BNF dialects which don't have prose nodes (and likewise elided for presentational EBNF), but do have effect for railroad diagrams. Space is allocated as if the nodes are present, but they are not actually drawn. So this allows for some limited manual control over alignment for a few situations.

With the invisible nodes rendered:
![image](https://user-images.githubusercontent.com/1371085/80896055-2532db00-8c9f-11ea-9875-37583739901b.png)

And how the output now looks, with them invisible:
![image](https://user-images.githubusercontent.com/1371085/80896058-324fca00-8c9f-11ea-86b9-d2fd484df9d5.png)

