### PR TITLE
Add note to README that `sid` is required for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Building depends on:
 
  * Any BSD make. This includes OpenBSD, FreeBSD and NetBSD make(1)
    and sjg's portable bmake (also packaged as pmake).
+   
+ * [`sid`](https://github.com/tendra/tendra/tree/main/sid)
 
  * A C compiler. Any should do, but GCC and clang are best supported.
 


### PR DESCRIPTION
I've stumped for quite some time, because of this error:

```console
% bmake -r install
<...>
sid -l ansi-c -s no-numeric-terminals -s no-terminals  src/abnf/parser.sid src/parser.act src/abnf/parser.c src/abnf/parser.h  || { rm -f src/abnf/parser.c src/abnf/parser.h; false; }
/bin/sh: sid: command not found
*** Error code 1

Stop.
bmake: stopped in /home/waffle/projects/repos/kgt
```

:)