### PR TITLE
Remove "exit" [1/n] (from output functions).

### DIFF
--- a/src/abnf/io.h
+++ b/src/abnf/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_ABNF_IO_H
 #define KGT_ABNF_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 /*
@@ -17,7 +19,8 @@ struct ast_rule;
 struct ast_rule *
 abnf_input(int (*f)(void *opaque), void *opaque);
 
-void
+WARN_UNUSED_RESULT
+int
 abnf_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/blab/io.h
+++ b/src/blab/io.h
@@ -7,11 +7,14 @@
 #ifndef KGT_BLAB_IO_H
 #define KGT_BLAB_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 #define blab_ast_unsupported (FEATURE_AST_INVISIBLE)
 
-void
+WARN_UNUSED_RESULT
+int
 blab_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/bnf/io.h
+++ b/src/bnf/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_BNF_IO_H
 #define KGT_BNF_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 #define bnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
@@ -14,7 +16,8 @@ struct ast_rule;
 struct ast_rule *
 bnf_input(int (*f)(void *opaque), void *opaque);
 
-void
+WARN_UNUSED_RESULT
+int
 bnf_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/bnf/output.c
+++ b/src/bnf/output.c
@@ -20,7 +20,8 @@
 
 #include "io.h"
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_term(const struct ast_term *term)
 {
 	assert(term->type != TYPE_GROUP);
@@ -42,7 +43,7 @@ output_term(const struct ast_term *term)
 
 	case TYPE_CI_LITERAL:
 		fprintf(stderr, "unimplemented\n");
-		exit(EXIT_FAILURE);
+		return 0;
 
 	case TYPE_CS_LITERAL: {
 			char c;
@@ -58,14 +59,16 @@ output_term(const struct ast_term *term)
 
 	case TYPE_PROSE:
 		fprintf(stderr, "unimplemented\n");
-		exit(EXIT_FAILURE);
+		return 0;
 
 	case TYPE_GROUP:
 		break;
 	}
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
@@ -73,13 +76,16 @@ output_alt(const struct ast_alt *alt)
 	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
-		output_term(term);
+		if (!output_term(term))
+			return 0;
 	}
 
 	printf("\n");
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_rule(const struct ast_rule *rule)
 {
 	const struct ast_alt *alt;
@@ -87,7 +93,8 @@ output_rule(const struct ast_rule *rule)
 	printf("<%s> ::=", rule->name);
 
 	for (alt = rule->alts; alt != NULL; alt = alt->next) {
-		output_alt(alt);
+		if (!output_alt(alt))
+			return 0;
 
 		if (alt->next != NULL) {
 			printf("\t|");
@@ -95,15 +102,19 @@ output_rule(const struct ast_rule *rule)
 	}
 
 	printf("\n");
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 bnf_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
 
 	for (p = grammar; p != NULL; p = p->next) {
-		output_rule(p);
+		if (!output_rule(p))
+			return 0;
 	}
+	return 1;
 }
 

--- a/src/compiler_specific.h
+++ b/src/compiler_specific.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef KGT_COMPILER_SPECIFIC_H
+#define KGT_COMPILER_SPECIFIC_H
+
+// Decorate a function. This indicates the caller must use the returned value.
+#undef WARN_UNUSED_RESULT
+#if defined(__GNUC__) || defined(__clang__)
+#define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#define WARN_UNUSED_RESULT
+#endif
+
+#endif /* end of include guard: KGT_COMPILER_SPECIFIC_H */

--- a/src/dot/io.h
+++ b/src/dot/io.h
@@ -7,9 +7,12 @@
 #ifndef KGT_DOT_IO_H
 #define KGT_DOT_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
-void
+WARN_UNUSED_RESULT
+int
 dot_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/dot/output.c
+++ b/src/dot/output.c
@@ -245,7 +245,8 @@ output_rule(const struct ast_rule *grammar,
 	output_alts(grammar, rule, rule->alts);
 }
 
-void
+WARN_UNUSED_RESULT
+int
 dot_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -259,5 +260,6 @@ dot_output(const struct ast_rule *grammar)
 	}
 
 	printf("}\n");
+	return 1;
 }
 

--- a/src/ebnfhtml5/io.h
+++ b/src/ebnfhtml5/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_EBNFHTML5_IO_H
 #define KGT_EBNFHTML5_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 /*
@@ -15,10 +17,12 @@ struct ast_rule;
  */
 #define ebnf_html5_ast_unsupported (FEATURE_AST_INVISIBLE)
 
-void
+WARN_UNUSED_RESULT
+int
 ebnf_html5_output(const struct ast_rule *grammar);
 
-void
+WARN_UNUSED_RESULT
+int
 ebnf_xhtml5_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/ebnfhtml5/output.c
+++ b/src/ebnfhtml5/output.c
@@ -327,7 +327,8 @@ output(const struct ast_rule *grammar, int xml)
 	printf(" </body>\n");
 }
 
-void
+WARN_UNUSED_RESULT
+int
 ebnf_html5_output(const struct ast_rule *grammar)
 {
 	printf("<!DOCTYPE html>\n");
@@ -337,9 +338,11 @@ ebnf_html5_output(const struct ast_rule *grammar)
 	output(grammar, 0);
 
 	printf("</html>\n");
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 ebnf_xhtml5_output(const struct ast_rule *grammar)
 {
 	printf("<?xml version='1.0' encoding='utf-8'?>\n");
@@ -352,5 +355,6 @@ ebnf_xhtml5_output(const struct ast_rule *grammar)
 	output(grammar, 1);
 
 	printf("</html>\n");
+	return 1;
 }
 

--- a/src/html5/io.h
+++ b/src/html5/io.h
@@ -7,14 +7,18 @@
 #ifndef KGT_HTML5_IO_H
 #define KGT_HTML5_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 html5_output(const struct ast_rule *);
 
-void
+WARN_UNUSED_RESULT
+int
 xhtml5_output(const struct ast_rule *);
 
 #endif

--- a/src/html5/output.c
+++ b/src/html5/output.c
@@ -41,7 +41,8 @@ void svg_render_rule(const struct tnode *node, const char *base,
 
 extern const char *css_file;
 
-void
+WARN_UNUSED_RESULT
+int
 cat(const char *in, const char *indent)
 {
 	FILE *f;
@@ -51,7 +52,7 @@ cat(const char *in, const char *indent)
 	f = fopen(in, "r");
 	if (f == NULL) {
 		perror(in);
-		exit(EXIT_FAILURE);
+		return 0;
 	}
 
 	fputs(indent, stdout);
@@ -71,9 +72,11 @@ cat(const char *in, const char *indent)
 	}
 
 	(void) fclose(f);
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output(const struct ast_rule *grammar, int xml)
 {
 	const struct ast_rule *p;
@@ -98,7 +101,8 @@ output(const struct ast_rule *grammar, int xml)
 	printf("      svg { margin-left: 30px; }\n");
 
 	if (css_file != NULL) {
-		cat(css_file, "      ");
+		if (!cat(css_file, "      "))
+			return 0;
 	}
 
 	printf("  </style>\n");
@@ -115,7 +119,7 @@ output(const struct ast_rule *grammar, int xml)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		if (prettify) {
@@ -148,21 +152,26 @@ output(const struct ast_rule *grammar, int xml)
 	}
 
 	printf(" </body>\n");
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 html5_output(const struct ast_rule *grammar)
 {
 	printf("<!DOCTYPE html>\n");
 	printf("<html>\n");
 	printf("\n");
 
-	output(grammar, 0);
+	if (!output(grammar, 0))
+		return 0;
 
 	printf("</html>\n");
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 xhtml5_output(const struct ast_rule *grammar)
 {
 	printf("<?xml version='1.0' encoding='utf-8'?>\n");
@@ -172,8 +181,10 @@ xhtml5_output(const struct ast_rule *grammar)
 	printf("  xmlns:xlink='http://www.w3.org/1999/xlink'>\n");
 	printf("\n");
 
-	output(grammar, 1);
+	if (!output(grammar, 1))
+		return 0;
 
 	printf("</html>\n");
+	return 1;
 }
 

--- a/src/iso-ebnf/io.h
+++ b/src/iso-ebnf/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_ISO_EBNF_IO_H
 #define KGT_ISO_EBNF_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 /*
@@ -19,7 +21,8 @@ struct ast_rule;
 struct ast_rule *
 iso_ebnf_input(int (*f)(void *opaque), void *opaque);
 
-void
+WARN_UNUSED_RESULT
+int
 iso_ebnf_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/rbnf/io.h
+++ b/src/rbnf/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_RBNF_IO_H
 #define KGT_RBNF_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 #define rbnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
@@ -14,7 +16,8 @@ struct ast_rule;
 struct ast_rule *
 rbnf_input(int (*f)(void *opaque), void *opaque);
 
-void
+WARN_UNUSED_RESULT
+int
 rbnf_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/rbnf/output.c
+++ b/src/rbnf/output.c
@@ -20,33 +20,41 @@
 
 #include "io.h"
 
-static void output_term(const struct ast_term *term);
+WARN_UNUSED_RESULT
+static int output_term(const struct ast_term *term);
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_group_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
 
 	for (term = alt->terms; term != NULL; term = term->next) {
-		output_term(term);
+		if (!output_term(term))
+			return 0;
 	}
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_group(const struct ast_alt *group)
 {
 	const struct ast_alt *alt;
 
 	for (alt = group; alt != NULL; alt = alt->next) {
-		output_group_alt(alt);
+		if (!output_group_alt(alt))
+			return 0;
 
 		if (alt->next != NULL) {
 			printf(" |");
 		}
 	}
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_term(const struct ast_term *term)
 {
 	const char *s, *e;
@@ -58,10 +66,10 @@ output_term(const struct ast_term *term)
 		const char *s;
 		const char *e;
 	} a[] = {
-		{ 1, 1, " (", " ) "     },
-		{ 1, 1, "",    ""       },
-		{ 0, 1, " [", " ] "     },
-		{ 0, 0, " [", " ... ] " }
+		{ 1 , 1 , " (" , " ) "     } ,
+		{ 1 , 1 , ""   , ""        } ,
+		{ 0 , 1 , " [" , " ] "     } ,
+		{ 0 , 0 , " [" , " ... ] " }
 	};
 
 	assert(term != NULL);
@@ -101,7 +109,7 @@ output_term(const struct ast_term *term)
 	case TYPE_CI_LITERAL:
 	case TYPE_CS_LITERAL:
 		fprintf(stderr, "unimplemented\n");
-		exit(EXIT_FAILURE);
+		return 0;
 
 	case TYPE_TOKEN:
 		printf(" <%s>", term->u.token);
@@ -109,17 +117,20 @@ output_term(const struct ast_term *term)
 
 	case TYPE_PROSE:
 		fprintf(stderr, "unimplemented\n");
-		exit(EXIT_FAILURE);
+		return 0;
 
 	case TYPE_GROUP:
-		output_group(term->u.group);
+		if (!output_group(term->u.group))
+			return 0;
 		break;
 	}
 
 	printf("%s", e);
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_alt(const struct ast_alt *alt)
 {
 	const struct ast_term *term;
@@ -128,13 +139,16 @@ output_alt(const struct ast_alt *alt)
 	assert(!alt->invisible);
 
 	for (term = alt->terms; term != NULL; term = term->next) {
-		output_term(term);
+		if (!output_term(term))
+			return 0;
 	}
 
 	printf("\n");
+	return 1;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 output_rule(const struct ast_rule *rule)
 {
 	const struct ast_alt *alt;
@@ -142,7 +156,8 @@ output_rule(const struct ast_rule *rule)
 	printf("<%s> ::=", rule->name);
 
 	for (alt = rule->alts; alt != NULL; alt = alt->next) {
-		output_alt(alt);
+		if (!output_alt(alt))
+			return 0;
 
 		if (alt->next != NULL) {
 			printf("\t|");
@@ -150,15 +165,19 @@ output_rule(const struct ast_rule *rule)
 	}
 
 	printf("\n");
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rbnf_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
 
 	for (p = grammar; p != NULL; p = p->next) {
-		output_rule(p);
+		if (!output_rule(p))
+			return 0;
 	}
+	return 1;
 }
 

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -7,9 +7,12 @@
 #ifndef KGT_REWRITE_H
 #define KGT_REWRITE_H
 
+#include "compiler_specific.h"
+
 struct ast_rule;
 
-void
+WARN_UNUSED_RESULT
+int
 rewrite_ci_literals(struct ast_rule *g);
 
 void

--- a/src/rrd/rewrite.h
+++ b/src/rrd/rewrite.h
@@ -7,10 +7,13 @@
 #ifndef KGT_RRD_REWRITE_H
 #define KGT_RRD_REWRITE_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 struct node;
 
-void
+WARN_UNUSED_RESULT
+int
 rewrite_rrd_ci_literals(struct node *n);
 
 #endif

--- a/src/rrdot/io.h
+++ b/src/rrdot/io.h
@@ -7,11 +7,14 @@
 #ifndef KGT_RRDOT_IO_H
 #define KGT_RRDOT_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrdot_output(const struct ast_rule *);
 
 #endif

--- a/src/rrdot/output.c
+++ b/src/rrdot/output.c
@@ -15,6 +15,7 @@
 
 #include "../txt.h"
 #include "../ast.h"
+#include "../compiler_specific.h"
 
 #include "../rrd/rrd.h"
 #include "../rrd/pretty.h"
@@ -226,7 +227,8 @@ rrd_print_dot(const char *prefix, const void *parent, const char *port,
 	}
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrdot_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -240,7 +242,7 @@ rrdot_output(const struct ast_rule *grammar)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		if (prettify) {
@@ -258,5 +260,6 @@ rrdot_output(const struct ast_rule *grammar)
 
 	printf("}\n");
 	printf("\n");
+	return 1;
 }
 

--- a/src/rrdump/io.h
+++ b/src/rrdump/io.h
@@ -7,11 +7,14 @@
 #ifndef KGT_RRDUMP_IO_H
 #define KGT_RRDUMP_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrdump_output(const struct ast_rule *);
 
 #endif

--- a/src/rrdump/output.c
+++ b/src/rrdump/output.c
@@ -14,6 +14,7 @@
 
 #include "../txt.h"
 #include "../ast.h"
+#include "../compiler_specific.h"
 
 #include "../rrd/rrd.h"
 #include "../rrd/pretty.h"
@@ -127,7 +128,8 @@ node_walk(FILE *f, const struct node *n, int depth)
 	}
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrdump_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -137,7 +139,7 @@ rrdump_output(const struct ast_rule *grammar)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		if (!prettify) {
@@ -158,5 +160,6 @@ rrdump_output(const struct ast_rule *grammar)
 
 		node_free(rrd);
 	}
+	return 1;
 }
 

--- a/src/rrll/io.h
+++ b/src/rrll/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_RRLL_IO_H
 #define KGT_RRLL_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 #define rrll_ast_unsupported (FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
@@ -14,7 +16,8 @@ struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrll_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/rrll/output.c
+++ b/src/rrll/output.c
@@ -24,6 +24,7 @@
 #include "../rrd/rewrite.h"
 #include "../rrd/node.h"
 #include "../rrd/list.h"
+#include "../compiler_specific.h"
 
 #include "io.h"
 
@@ -225,7 +226,8 @@ node_walk(FILE *f, const struct node *n)
 	}
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrll_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -235,7 +237,7 @@ rrll_output(const struct ast_rule *grammar)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		if (prettify) {
@@ -243,7 +245,8 @@ rrll_output(const struct ast_rule *grammar)
 		}
 
 		/* TODO: pass in unsupported bitmap */
-		rewrite_rrd_ci_literals(rrd);
+		if (!rewrite_rrd_ci_literals(rrd))
+			return 0;
 
 		printf("[`");
 		escputs(p->name, stdout);
@@ -254,5 +257,6 @@ rrll_output(const struct ast_rule *grammar)
 
 		node_free(rrd);
 	}
+	return 1;
 }
 

--- a/src/rrparcon/io.h
+++ b/src/rrparcon/io.h
@@ -14,7 +14,8 @@ struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrparcon_output(const struct ast_rule *);
 
 #endif

--- a/src/rrta/io.h
+++ b/src/rrta/io.h
@@ -14,7 +14,8 @@ struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrta_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/rrta/output.c
+++ b/src/rrta/output.c
@@ -142,7 +142,8 @@ normal(const struct list *list)
 	return 0;
 }
 
-static void
+WARN_UNUSED_RESULT
+static int
 node_walk(FILE *f, const struct node *n, int depth)
 {
 	assert(f != NULL);
@@ -150,8 +151,7 @@ node_walk(FILE *f, const struct node *n, int depth)
 	if (n == NULL) {
 		print_indent(f, depth);
 		fprintf(f, "Skip()");
-
-		return;
+		return 1;
 	}
 
 	switch (n->type) {
@@ -159,7 +159,7 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 	case NODE_CI_LITERAL:
 		fprintf(stderr, "unimplemented\n");
-		exit(EXIT_FAILURE);
+		return 0;
 
 	case NODE_CS_LITERAL:
 		print_indent(f, depth);
@@ -179,7 +179,7 @@ node_walk(FILE *f, const struct node *n, int depth)
 
 	case NODE_PROSE:
 		fprintf(stderr, "unimplemented\n");
-		exit(EXIT_FAILURE);
+		return 0;
 
 	case NODE_ALT:
 	case NODE_ALT_SKIPPABLE:
@@ -192,7 +192,8 @@ node_walk(FILE *f, const struct node *n, int depth)
 		}
 
 		for (p = n->u.alt; p != NULL; p = p->next) {
-			node_walk(f, p->node, depth + 1);
+			if (!node_walk(f, p->node, depth + 1))
+				return 0;
 			if (p->next != NULL) {
 				fprintf(f, ",");
 				fprintf(f, "\n");
@@ -206,7 +207,8 @@ node_walk(FILE *f, const struct node *n, int depth)
 		print_indent(f, depth);
 		fprintf(f, "Sequence(\n");
 		for (p = n->u.seq; p != NULL; p = p->next) {
-			node_walk(f, p->node, depth + 1);
+			if (!node_walk(f, p->node, depth + 1))
+				return 0;
 			if (p->next != NULL) {
 				fprintf(f, ",");
 				fprintf(f, "\n");
@@ -220,17 +222,22 @@ node_walk(FILE *f, const struct node *n, int depth)
 		print_indent(f, depth);
 		fprintf(f, "%s(\n", n->u.loop.min == 0 ? "ZeroOrMore" : "OneOrMore");
 
-		node_walk(f, n->u.loop.forward, depth + 1);
+		if (!node_walk(f, n->u.loop.forward, depth + 1))
+			return 0;
 		fprintf(f, ",\n");
 
-		node_walk(f, n->u.loop.backward, depth + 1);
+		if (!node_walk(f, n->u.loop.backward, depth + 1))
+			return 0;
 		fprintf(f, ")");
 
 		break;
 	}
+	return 1;
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrta_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -240,7 +247,7 @@ rrta_output(const struct ast_rule *grammar)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		if (prettify) {
@@ -248,17 +255,20 @@ rrta_output(const struct ast_rule *grammar)
 		}
 
 		/* TODO: pass in unsupported bitmap */
-		rewrite_rrd_ci_literals(rrd);
+		if (!rewrite_rrd_ci_literals(rrd))
+			return 0;
 
 		printf("add('");
 		escputs(p->name, stdout);
 		printf("', Diagram(\n");
 
-		node_walk(stdout, rrd, 1);
+		if (!node_walk(stdout, rrd, 1))
+			return 0;
 		printf("));\n");
 		printf("\n");
 
 		node_free(rrd);
 	}
+	return 1;
 }
 

--- a/src/rrtdump/io.h
+++ b/src/rrtdump/io.h
@@ -7,11 +7,14 @@
 #ifndef KGT_RRTDUMP_IO_H
 #define KGT_RRTDUMP_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrtdump_output(const struct ast_rule *);
 
 #endif

--- a/src/rrtdump/output.c
+++ b/src/rrtdump/output.c
@@ -20,6 +20,7 @@
 #include "../rrd/node.h"
 #include "../rrd/list.h"
 #include "../rrd/tnode.h"
+#include "../compiler_specific.h"
 
 #include "io.h"
 
@@ -168,7 +169,8 @@ dim_mono_string(const char *s, unsigned *w, unsigned *a, unsigned *d)
 	*d = 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrtdump_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -190,7 +192,7 @@ rrtdump_output(const struct ast_rule *grammar)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		tnode = rrd_to_tnode(rrd, &dim);
@@ -218,5 +220,6 @@ rrtdump_output(const struct ast_rule *grammar)
 		tnode_free(tnode);
 		node_free(rrd);
 	}
+	return 1;
 }
 

--- a/src/rrtext/io.h
+++ b/src/rrtext/io.h
@@ -7,14 +7,18 @@
 #ifndef KGT_RRTEXT_IO_H
 #define KGT_RRTEXT_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 rrutf8_output(const struct ast_rule *);
 
-void
+WARN_UNUSED_RESULT
+int
 rrtext_output(const struct ast_rule *);
 
 #endif

--- a/src/rrtext/output.c
+++ b/src/rrtext/output.c
@@ -24,6 +24,7 @@
 #include "../txt.h"
 #include "../ast.h"
 #include "../xalloc.h"
+#include "../compiler_specific.h"
 
 #include "../rrd/rrd.h"
 #include "../rrd/pretty.h"
@@ -547,7 +548,8 @@ rr_output(const struct ast_rule *grammar, struct dim *dim, int utf8)
 	}
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrutf8_output(const struct ast_rule *grammar)
 {
 	struct dim dim = {
@@ -562,9 +564,11 @@ rrutf8_output(const struct ast_rule *grammar)
 	};
 
 	rr_output(grammar, &dim, 1);
+	return 1;
 }
 
-void
+WARN_UNUSED_RESULT
+int
 rrtext_output(const struct ast_rule *grammar)
 {
 	struct dim dim = {
@@ -579,5 +583,6 @@ rrtext_output(const struct ast_rule *grammar)
 	};
 
 	rr_output(grammar, &dim, 0);
+	return 1;
 }
 

--- a/src/sid/io.h
+++ b/src/sid/io.h
@@ -7,11 +7,14 @@
 #ifndef KGT_SID_IO_H
 #define KGT_SID_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 #define sid_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
-void
+WARN_UNUSED_RESULT
+int
 sid_output(const struct ast_rule *grammar);
 
 #endif

--- a/src/svg/io.h
+++ b/src/svg/io.h
@@ -7,12 +7,15 @@
 #ifndef KGT_SVG_IO_H
 #define KGT_SVG_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 extern int debug;
 extern int prettify;
 
-void
+WARN_UNUSED_RESULT
+int
 svg_output(const struct ast_rule *);
 
 #endif

--- a/src/svg/output.c
+++ b/src/svg/output.c
@@ -801,7 +801,8 @@ struct dim svg_dim = {
 	0
 };
 
-void
+WARN_UNUSED_RESULT
+int
 svg_output(const struct ast_rule *grammar)
 {
 	const struct ast_rule *p;
@@ -831,7 +832,7 @@ svg_output(const struct ast_rule *grammar)
 
 		if (!ast_to_rrd(p, &rrd)) {
 			perror("ast_to_rrd");
-			return;
+			return 0;
 		}
 
 		if (prettify) {
@@ -908,5 +909,6 @@ svg_output(const struct ast_rule *grammar)
 	free(a);
 
 	printf("</svg>\n");
+	return 1;
 }
 

--- a/src/wsn/io.h
+++ b/src/wsn/io.h
@@ -7,6 +7,8 @@
 #ifndef KGT_WSN_IO_H
 #define KGT_WSN_IO_H
 
+#include "../compiler_specific.h"
+
 struct ast_rule;
 
 #define wsn_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
@@ -14,7 +16,8 @@ struct ast_rule;
 struct ast_rule *
 wsn_input(int (*f)(void *opaque), void *opaque);
 
-void
+WARN_UNUSED_RESULT
+int
 wsn_output(const struct ast_rule *grammar);
 
 #endif


### PR DESCRIPTION
Using `exit(EXIT_FAILURE)` in the middle of a function makes kgt hard to
be embedded as a library, because it interrupt the caller.

This patch removes them in all the generators. This is replaced by
returning the status (a boolean) to the caller. The caller will be a
good position to decide what to do with the error.

Issue:
https://github.com/katef/kgt/issues/38