### PR TITLE
Update fpm for broken packaging in CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,6 +27,8 @@ jobs:
       run: |
         uname -a
         sudo apt-get install bmake
+        sudo gem install --no-document fpm
+        fpm -v
         ${{ matrix.cc }} --version
 
     - name: make
@@ -44,13 +46,11 @@ jobs:
     - name: install
       run: |
         bmake -r -j 2 PKGCONF=pkg-config CC=${{ matrix.cc }} PREFIX=prefix/usr install
-        mkdir pkg
 
     - name: Package
-      uses: bpicode/github-action-fpm@master
-      with:
-        fpm_args: ''
-        fpm_opts: '-C prefix -p pkg/ -n kgt -t ${{ matrix.pkg }} -v 0.${{ github.sha }} -m kate@elide.org -s dir'
+      run: |
+        mkdir pkg
+        fpm -C prefix -p pkg/ -n kgt -t ${{ matrix.pkg }} -v 0.${{ github.sha }} -m kate@elide.org -s dir
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
recently fpm started giving errors I don't understand, about some ruby-related `require` thing. I think it's the same bug reported here: https://github.com/jordansissel/fpm/issues/1716

I had been using bpicode/github-action-fpm to run fpm (which I think does it in a docker image). In this PR I'm removing that, and installing fpm by hand instead. This way I can better see what's happening I guess. I don't know how to use docker or ruby, or do CI stuff really, so the fewer things the better for me.

[fpm's docs on installing](https://github.com/jordansissel/fpm/blob/master/docs/installing.rst) say it depends on:

    apt-get install ruby ruby-dev rubygems build-essential

[github's ubuntu environment](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md) provides these already.

This still gives the same warning:
```
fpm -v
Doing `require 'backports'` is deprecated and will not load any backport in the next major release.
Require just the needed backports instead, or 'backports/latest'.
1.11.0
```
so I have no idea what's happening here with the versions, but it works again for now, so hooray! Good job me.