### PR TITLE
Stop using exit in parser.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,7 @@ SRC += src/ast.c
 SRC += src/ast_binary.c
 SRC += src/bitmap.c
 SRC += src/main.c
+SRC += src/parsing_error.c
 SRC += src/rewrite_ci.c
 SRC += src/rewrite_invisible.c
 SRC += src/txt.c
@@ -22,6 +23,7 @@ ${BUILD}/bin/kgt: ${BUILD}/src/ast.o
 ${BUILD}/bin/kgt: ${BUILD}/src/ast_binary.o
 ${BUILD}/bin/kgt: ${BUILD}/src/bitmap.o
 ${BUILD}/bin/kgt: ${BUILD}/src/main.o
+${BUILD}/bin/kgt: ${BUILD}/src/parsing_error.o
 ${BUILD}/bin/kgt: ${BUILD}/src/rewrite_ci.o
 ${BUILD}/bin/kgt: ${BUILD}/src/rewrite_invisible.o
 ${BUILD}/bin/kgt: ${BUILD}/src/txt.o

--- a/src/abnf/io.h
+++ b/src/abnf/io.h
@@ -8,7 +8,7 @@
 #define KGT_ABNF_IO_H
 
 #include "../compiler_specific.h"
-
+#include "../parsing_error.h"
 struct ast_rule;
 
 /*
@@ -17,7 +17,7 @@ struct ast_rule;
  */
 
 struct ast_rule *
-abnf_input(int (*f)(void *opaque), void *opaque);
+abnf_input(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors);
 
 WARN_UNUSED_RESULT
 int

--- a/src/abnf/parser.h
+++ b/src/abnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 316 "src/parser.act"
+#line 311 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_abnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 871 "src/parser.act"
+#line 861 "src/parser.act"
 
 
 #line 31 "src/abnf/parser.h"

--- a/src/ast.c
+++ b/src/ast.c
@@ -239,4 +239,3 @@ ast_free_term(struct ast_term *term)
 	/* XXX: free contents */
 	free(term);
 }
-

--- a/src/ast.h
+++ b/src/ast.h
@@ -122,4 +122,3 @@ int
 ast_binary(const struct ast_rule *ast);
 
 #endif
-

--- a/src/bnf/io.h
+++ b/src/bnf/io.h
@@ -8,13 +8,13 @@
 #define KGT_BNF_IO_H
 
 #include "../compiler_specific.h"
-
+#include "../parsing_error.h"
 struct ast_rule;
 
 #define bnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 struct ast_rule *
-bnf_input(int (*f)(void *opaque), void *opaque);
+bnf_input(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors);
 
 WARN_UNUSED_RESULT
 int

--- a/src/bnf/parser.h
+++ b/src/bnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 316 "src/parser.act"
+#line 311 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_bnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 871 "src/parser.act"
+#line 861 "src/parser.act"
 
 
 #line 31 "src/bnf/parser.h"

--- a/src/iso-ebnf/io.h
+++ b/src/iso-ebnf/io.h
@@ -8,7 +8,7 @@
 #define KGT_ISO_EBNF_IO_H
 
 #include "../compiler_specific.h"
-
+#include "../parsing_error.h"
 struct ast_rule;
 
 /*
@@ -19,7 +19,7 @@ struct ast_rule;
 #define iso_ebnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_PROSE | FEATURE_AST_BINARY)
 
 struct ast_rule *
-iso_ebnf_input(int (*f)(void *opaque), void *opaque);
+iso_ebnf_input(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors);
 
 WARN_UNUSED_RESULT
 int

--- a/src/iso-ebnf/parser.h
+++ b/src/iso-ebnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 316 "src/parser.act"
+#line 311 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_iso_Hebnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 871 "src/parser.act"
+#line 861 "src/parser.act"
 
 
 #line 31 "src/iso-ebnf/parser.h"

--- a/src/parser.act
+++ b/src/parser.act
@@ -40,6 +40,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../parsing_error.h"
 	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
@@ -97,6 +98,8 @@
 		/* TODO: use lx's generated conveniences for the pattern buffer */
 		char a[512];
 		char *p;
+
+		parsing_error_queue errors;
 	};
 
 	#define CURRENT_TERMINAL (act_state->lex_tok)
@@ -107,27 +110,6 @@
 	#define RESTORE_LEXER    do { act_state->lex_tok = act_state->lex_tok_save; } while (0)
 
 	extern int allow_undefined;
-
-	static const char *
-	pattern_buffer(struct lex_state *lex_state)
-	{
-		const char *s;
-
-		assert(lex_state != NULL);
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		s = xstrdup(lex_state->a);
-		if (s == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-
-		return s;
-	}
 
 	static const char *
 	prefix(int base)
@@ -278,32 +260,52 @@
 	}
 
 	static void
-	err(const struct lex_state *lex_state, const char *fmt, ...)
+	err(struct lex_state *lex_state, const char *fmt, ...)
 	{
+		assert(lex_state != NULL);
+
+		parsing_error error;
+		error.line = lex_state->lx.start.line;
+		error.column= lex_state->lx.start.col;
 		va_list ap;
+		va_start(ap, fmt);
+		vsnprintf(error.description, PARSING_ERROR_DESCRIPTION_SIZE, fmt, ap);
+		va_end(ap);
+
+		parsing_error_queue_push(&(lex_state->errors), error);
+	}
+
+	static void
+	err_expected(struct lex_state *lex_state, const char *token)
+	{
+		err(lex_state, "Syntax error: expected %s", token);
+	}
+
+	static void
+	err_unimplemented(struct lex_state *lex_state, const char *s)
+	{
+		err(lex_state, "Unimplemented: %s", s);
+	}
+
+	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
 
 		assert(lex_state != NULL);
 
-		va_start(ap, fmt);
-		fprintf(stderr, "%u:%u: ",
-			lex_state->lx.start.line, lex_state->lx.start.col);
-		vfprintf(stderr, fmt, ap);
-		fprintf(stderr, "\n");
-		va_end(ap);
-	}
+		/* TODO */
+		*lex_state->p++ = '\0';
 
-	static void
-	err_expected(const struct lex_state *lex_state, const char *token)
-	{
-		err(lex_state, "Syntax error: expected %s", token);
-		exit(EXIT_FAILURE);
-	}
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
 
-	static void
-	err_unimplemented(const struct lex_state *lex_state, const char *s)
-	{
-		err(lex_state, "Unimplemented: %s", s);
-		exit(EXIT_FAILURE);
+		lex_state->p = lex_state->a;
+
+		return s;
 	}
 
 @}, @{
@@ -686,10 +688,8 @@
 
 	<add-rule-to-list>: (l :ast_rule, r :ast_rule) -> () = @{
 		if (ast_find_rule(@l, @r->name)) {
-			fprintf(stderr, "production rule <%s> already exists\n", @r->name);
-			/* TODO: print location of this and previous definition */
-			/* TODO: handle as warning; add rule anyway, and bail out at end */
-			exit(EXIT_FAILURE);
+      err(lex_state, "production rule <%s> already exists", @r->name);
+			return;
 		}
 
 		assert(@r->next == NULL);
@@ -697,7 +697,7 @@
 	@};
 
 	<current-rules>: () -> (l :ast_rule) = @{
-		fprintf(stderr, "unimplemented\n");
+    err(lex_state, "unimplemented");
 		@l = NULL;
 		@!;
 	@};
@@ -709,7 +709,7 @@
 	@};
 
 	<add-alts>: (r :ast_rule, a :ast_alt) -> () = @{
-		fprintf(stderr, "unimplemented\n");
+		err(lex_state, "Unimplemented");
 		@!;
 	@};
 
@@ -753,7 +753,7 @@
 	}
 
 	struct ast_rule *
-	FORM_INPUT(int (*f)(void *opaque), void *opaque)
+	FORM_INPUT(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -777,6 +777,7 @@
 
 		lex_state    = &lex_state_s;
 		lex_state->p = lex_state->a;
+		lex_state->errors = NULL;
 
 		lx = &lex_state->lx;
 
@@ -797,8 +798,8 @@
 		lx->clear      = CAT(LX_PREFIX, _dynclear);
 		lx->free       = CAT(LX_PREFIX, _dynfree);
 
-	/* XXX */
-	lx->free = NULL;
+		/* XXX */
+		lx->free = NULL;
 
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
@@ -816,9 +817,6 @@
 			const struct ast_alt *q;
 			struct ast_term *t;
 			struct ast_rule *r;
-			int ok;
-
-			ok = 1;
 
 			for (p = g; p != NULL; p = p->next) {
 				for (q = p->alts; q != NULL; q = q->next) {
@@ -836,11 +834,8 @@
 						}
 
 						if (!allow_undefined) {
-							fprintf(stderr, "production rule <%s> not defined\n", t->u.rule->name);
-							/* TODO: print location of this and previous definition */
+							err(lex_state, "production rule <%s> not defined", t->u.rule->name);
 							/* XXX: would leak the ast_rule here */
-
-							ok = 0;
 							continue;
 						}
 
@@ -857,16 +852,12 @@
 					}
 				}
 			}
-
-			if (!ok) {
-				exit(EXIT_FAILURE);
-			}
 		}
 
+		*errors = lex_state->errors;
 		return g;
 	}
 
 @}, @{
 
 @};
-

--- a/src/parsing_error.c
+++ b/src/parsing_error.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+#include "parsing_error.h"
+
+#include "xalloc.h"
+#include <stddef.h>
+#include <stdlib.h>
+
+void parsing_error_queue_push(parsing_error_queue *queue, parsing_error error) {
+	/* Find the end of the queue: */
+	parsing_error_queue_element **tail = queue;
+	while (*tail != NULL)
+		tail = &((*tail)->next);
+
+	/* Allocate a parsing_error_queue and initialize it: */
+	*tail = xmalloc(sizeof(parsing_error_queue_element));
+	(*tail)->error = error;
+	(*tail)->next = NULL;
+}
+
+int parsing_error_queue_pop(parsing_error_queue *queue, parsing_error *error) {
+	if (!*queue)
+		return 0;
+
+	parsing_error_queue_element* head = *queue;
+	*error = head->error;
+	*queue = head->next;
+	free(head);
+	return 1;
+}

--- a/src/parsing_error.h
+++ b/src/parsing_error.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef KGT_PARSING_ERROR_H
+#define KGT_PARSING_ERROR_H
+
+#define PARSING_ERROR_DESCRIPTION_SIZE (256)
+
+struct parsing_error {
+	int line;
+	int column;
+	char description[PARSING_ERROR_DESCRIPTION_SIZE];
+};
+
+struct parsing_error_queue_element {
+	struct parsing_error error;
+	struct parsing_error_queue_element* next;
+};
+
+typedef struct parsing_error parsing_error;
+typedef struct parsing_error_queue_element parsing_error_queue_element;
+typedef parsing_error_queue_element* parsing_error_queue;
+
+void parsing_error_queue_push(parsing_error_queue* queue, parsing_error error);
+int parsing_error_queue_pop(parsing_error_queue* queue, parsing_error* error);
+
+#endif // KGT_PARSING_ERROR_H

--- a/src/rbnf/io.h
+++ b/src/rbnf/io.h
@@ -8,13 +8,13 @@
 #define KGT_RBNF_IO_H
 
 #include "../compiler_specific.h"
-
+#include "../parsing_error.h"
 struct ast_rule;
 
 #define rbnf_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 struct ast_rule *
-rbnf_input(int (*f)(void *opaque), void *opaque);
+rbnf_input(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors);
 
 WARN_UNUSED_RESULT
 int

--- a/src/rbnf/parser.h
+++ b/src/rbnf/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 316 "src/parser.act"
+#line 311 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_rbnf(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 871 "src/parser.act"
+#line 861 "src/parser.act"
 
 
 #line 31 "src/rbnf/parser.h"

--- a/src/wsn/io.h
+++ b/src/wsn/io.h
@@ -8,13 +8,13 @@
 #define KGT_WSN_IO_H
 
 #include "../compiler_specific.h"
-
+#include "../parsing_error.h"
 struct ast_rule;
 
 #define wsn_ast_unsupported (FEATURE_AST_CI_LITERAL | FEATURE_AST_BINARY | FEATURE_AST_INVISIBLE)
 
 struct ast_rule *
-wsn_input(int (*f)(void *opaque), void *opaque);
+wsn_input(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors);
 
 WARN_UNUSED_RESULT
 int

--- a/src/wsn/parser.c
+++ b/src/wsn/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 103 "src/parser.act"
+#line 32 "src/parser.act"
 
 
 	#include <assert.h>
@@ -21,6 +21,7 @@
 	#include <errno.h>
 	#include <ctype.h>
 
+	#include "../parsing_error.h"
 	#include "../txt.h"
 	#include "../ast.h"
 	#include "../xalloc.h"
@@ -78,6 +79,8 @@
 		/* TODO: use lx's generated conveniences for the pattern buffer */
 		char a[512];
 		char *p;
+
+		parsing_error_queue errors;
 	};
 
 	#define CURRENT_TERMINAL (act_state->lex_tok)
@@ -88,27 +91,6 @@
 	#define RESTORE_LEXER    do { act_state->lex_tok = act_state->lex_tok_save; } while (0)
 
 	extern int allow_undefined;
-
-	static const char *
-	pattern_buffer(struct lex_state *lex_state)
-	{
-		const char *s;
-
-		assert(lex_state != NULL);
-
-		/* TODO */
-		*lex_state->p++ = '\0';
-
-		s = xstrdup(lex_state->a);
-		if (s == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-
-		lex_state->p = lex_state->a;
-
-		return s;
-	}
 
 	static const char *
 	prefix(int base)
@@ -259,35 +241,55 @@
 	}
 
 	static void
-	err(const struct lex_state *lex_state, const char *fmt, ...)
+	err(struct lex_state *lex_state, const char *fmt, ...)
 	{
+		assert(lex_state != NULL);
+
+		parsing_error error;
+		error.line = lex_state->lx.start.line;
+		error.column= lex_state->lx.start.col;
 		va_list ap;
+		va_start(ap, fmt);
+		vsnprintf(error.description, PARSING_ERROR_DESCRIPTION_SIZE, fmt, ap);
+		va_end(ap);
+
+		parsing_error_queue_push(&(lex_state->errors), error);
+	}
+
+	static void
+	err_expected(struct lex_state *lex_state, const char *token)
+	{
+		err(lex_state, "Syntax error: expected %s", token);
+	}
+
+	static void
+	err_unimplemented(struct lex_state *lex_state, const char *s)
+	{
+		err(lex_state, "Unimplemented: %s", s);
+	}
+
+	static const char *
+	pattern_buffer(struct lex_state *lex_state)
+	{
+		const char *s;
 
 		assert(lex_state != NULL);
 
-		va_start(ap, fmt);
-		fprintf(stderr, "%u:%u: ",
-			lex_state->lx.start.line, lex_state->lx.start.col);
-		vfprintf(stderr, fmt, ap);
-		fprintf(stderr, "\n");
-		va_end(ap);
+		/* TODO */
+		*lex_state->p++ = '\0';
+
+		s = xstrdup(lex_state->a);
+		if (s == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+
+		lex_state->p = lex_state->a;
+
+		return s;
 	}
 
-	static void
-	err_expected(const struct lex_state *lex_state, const char *token)
-	{
-		err(lex_state, "Syntax error: expected %s", token);
-		exit(EXIT_FAILURE);
-	}
-
-	static void
-	err_unimplemented(const struct lex_state *lex_state, const char *s)
-	{
-		err(lex_state, "Unimplemented: %s", s);
-		exit(EXIT_FAILURE);
-	}
-
-#line 291 "src/wsn/parser.c"
+#line 293 "src/wsn/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -337,11 +339,11 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 640 "src/parser.act"
+#line 641 "src/parser.act"
 
 		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 345 "src/wsn/parser.c"
+#line 347 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 		}
@@ -366,16 +368,16 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 640 "src/parser.act"
+#line 641 "src/parser.act"
 
 		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 374 "src/wsn/parser.c"
+#line 376 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-one */
 			{
-#line 543 "src/parser.act"
+#line 544 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 1;
@@ -384,19 +386,19 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 388 "src/wsn/parser.c"
+#line 390 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-one */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 552 "src/parser.act"
+#line 553 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 400 "src/wsn/parser.c"
+#line 402 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -421,16 +423,16 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-term */
 			{
-#line 640 "src/parser.act"
+#line 641 "src/parser.act"
 
 		(ZIt) = ast_make_group_term(act_state->invisible, (ZIa));
 	
-#line 429 "src/wsn/parser.c"
+#line 431 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-group-term */
 			/* BEGINNING OF ACTION: rep-zero-or-more */
 			{
-#line 534 "src/parser.act"
+#line 535 "src/parser.act"
 
 		(ZImin) = 0;
 		(ZImax) = 0;
@@ -439,19 +441,19 @@ prod_factor(lex_state lex_state, act_state act_state, map_term *ZOt)
 		(void) (ZImin);
 		(void) (ZImax);
 	
-#line 443 "src/wsn/parser.c"
+#line 445 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: rep-zero-or-more */
 			/* BEGINNING OF ACTION: set-repeat */
 			{
-#line 552 "src/parser.act"
+#line 553 "src/parser.act"
 
 		assert((ZImax) >= (ZImin) || !(ZImax));
 
 		(ZIt)->min = (ZImin);
 		(ZIt)->max = (ZImax);
 	
-#line 455 "src/wsn/parser.c"
+#line 457 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: set-repeat */
 		}
@@ -569,13 +571,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 341 "src/parser.act"
+#line 340 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 1);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 579 "src/wsn/parser.c"
+#line 581 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -585,13 +587,13 @@ ZL2_body:;
 					{
 						/* BEGINNING OF EXTRACT: ESC */
 						{
-#line 335 "src/parser.act"
+#line 334 "src/parser.act"
 
 		assert(strlen(lex_state->buf.a) == 2);
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 595 "src/wsn/parser.c"
+#line 597 "src/wsn/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -609,14 +611,14 @@ ZL2_body:;
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 613 "src/wsn/parser.c"
+#line 615 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: body */
 			goto ZL2_body;
 			/* END OF INLINE: body */
 		}
-		/*UNREACHED*/
+		/* UNREACHED */
 	case (ERROR_TERMINAL):
 		return;
 	default:
@@ -639,11 +641,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-empty-term */
 			{
-#line 579 "src/parser.act"
+#line 580 "src/parser.act"
 
 		(ZIt) = ast_make_empty_term(act_state->invisible);
 	
-#line 647 "src/wsn/parser.c"
+#line 649 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-empty-term */
 		}
@@ -654,7 +656,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 354 "src/parser.act"
+#line 346 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -671,13 +673,13 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 675 "src/wsn/parser.c"
+#line 677 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-rule-term */
 			{
-#line 591 "src/parser.act"
+#line 584 "src/parser.act"
 
 		struct ast_rule *r;
 
@@ -695,7 +697,7 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 
 		(ZIt) = ast_make_rule_term(act_state->invisible, r);
 	
-#line 699 "src/wsn/parser.c"
+#line 701 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-rule-term */
 		}
@@ -709,12 +711,12 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			case (TOK_CS__LITERAL):
 				/* BEGINNING OF EXTRACT: CS_LITERAL */
 				{
-#line 377 "src/parser.act"
+#line 378 "src/parser.act"
 
 		ZIx.p = pattern_buffer(lex_state);
 		ZIx.n = strlen(ZIx.p);
 	
-#line 718 "src/wsn/parser.c"
+#line 720 "src/wsn/parser.c"
 				}
 				/* END OF EXTRACT: CS_LITERAL */
 				break;
@@ -727,11 +729,11 @@ prod_term(lex_state lex_state, act_state act_state, map_term *ZOt)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-cs-literal-term */
 			{
-#line 612 "src/parser.act"
+#line 613 "src/parser.act"
 
 		(ZIt) = ast_make_literal_term(act_state->invisible, &(ZIx), 0);
 	
-#line 735 "src/wsn/parser.c"
+#line 737 "src/wsn/parser.c"
 			}
 			/* END OF ACTION: make-cs-literal-term */
 		}
@@ -765,7 +767,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		case (TOK_IDENT):
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 354 "src/parser.act"
+#line 346 "src/parser.act"
 
 		/*
 		 * This rtrim() is for EBNF, which would require n-token lookahead
@@ -782,7 +784,7 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 786 "src/wsn/parser.c"
+#line 788 "src/wsn/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			break;
@@ -806,11 +808,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-equals */
 				{
-#line 732 "src/parser.act"
+#line 730 "src/parser.act"
 
 		err_expected(lex_state, "production rule assignment");
 	
-#line 814 "src/wsn/parser.c"
+#line 816 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-equals */
 			}
@@ -824,11 +826,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 		}
 		/* BEGINNING OF ACTION: make-rule */
 		{
-#line 669 "src/parser.act"
+#line 670 "src/parser.act"
 
 		(ZIr) = ast_make_rule((ZIs), (ZIa));
 	
-#line 832 "src/wsn/parser.c"
+#line 834 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-rule */
 		/* BEGINNING OF INLINE: 88 */
@@ -847,11 +849,11 @@ prod_rule(lex_state lex_state, act_state act_state, map_rule *ZOr)
 			{
 				/* BEGINNING OF ACTION: err-expected-sep */
 				{
-#line 728 "src/parser.act"
+#line 726 "src/parser.act"
 
 		err_expected(lex_state, "production rule separator");
 	
-#line 855 "src/wsn/parser.c"
+#line 857 "src/wsn/parser.c"
 				}
 				/* END OF ACTION: err-expected-sep */
 			}
@@ -893,21 +895,21 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-empty-rule */
 		{
-#line 673 "src/parser.act"
+#line 674 "src/parser.act"
 
 		(ZIl) = NULL;
 	
-#line 901 "src/wsn/parser.c"
+#line 903 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: make-empty-rule */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 720 "src/parser.act"
+#line 717 "src/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 911 "src/wsn/parser.c"
+#line 913 "src/wsn/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -930,13 +932,11 @@ prod_93(lex_state lex_state, act_state act_state, map_rule *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-rule-to-list */
 			{
-#line 688 "src/parser.act"
+#line 689 "src/parser.act"
 
 		if (ast_find_rule((ZIr), (*ZIl)->name)) {
-			fprintf(stderr, "production rule <%s> already exists\n", (*ZIl)->name);
-			/* TODO: print location of this and previous definition */
-			/* TODO: handle as warning; add rule anyway, and bail out at end */
-			exit(EXIT_FAILURE);
+      err(lex_state, "production rule <%s> already exists", (*ZIl)->name);
+			return;
 		}
 
 		assert((*ZIl)->next == NULL);
@@ -984,7 +984,7 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 				{
 					/* BEGINNING OF ACTION: err-expected-alt */
 					{
-#line 724 "src/parser.act"
+#line 722 "src/parser.act"
 
 		err_expected(lex_state, "alternative separator");
 	
@@ -1002,7 +1002,7 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			}
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 665 "src/parser.act"
+#line 666 "src/parser.act"
 
 		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
@@ -1011,7 +1011,7 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 			/* END OF ACTION: make-alt */
 			/* BEGINNING OF ACTION: add-alt-to-list */
 			{
-#line 683 "src/parser.act"
+#line 684 "src/parser.act"
 
 		assert((ZIl)->next == NULL);
 		(ZIl)->next = (ZIa);
@@ -1025,7 +1025,7 @@ prod_94(lex_state lex_state, act_state act_state, map_term *ZIt, map_alt *ZOl)
 		{
 			/* BEGINNING OF ACTION: make-alt */
 			{
-#line 665 "src/parser.act"
+#line 666 "src/parser.act"
 
 		(ZIl) = ast_make_alt(act_state->invisible, (*ZIt));
 	
@@ -1061,7 +1061,7 @@ prod_95(lex_state lex_state, act_state act_state, map_term *ZIl)
 			}
 			/* BEGINNING OF ACTION: add-term-to-list */
 			{
-#line 678 "src/parser.act"
+#line 679 "src/parser.act"
 
 		assert((*ZIl)->next == NULL);
 		(*ZIl)->next = (ZIt);
@@ -1084,7 +1084,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 869 "src/parser.act"
+#line 738 "src/parser.act"
 
 
 	static int
@@ -1103,7 +1103,7 @@ ZL1:;
 	}
 
 	struct ast_rule *
-	FORM_INPUT(int (*f)(void *opaque), void *opaque)
+	FORM_INPUT(int (*f)(void *opaque), void *opaque, parsing_error_queue* errors)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -1127,6 +1127,7 @@ ZL1:;
 
 		lex_state    = &lex_state_s;
 		lex_state->p = lex_state->a;
+		lex_state->errors = NULL;
 
 		lx = &lex_state->lx;
 
@@ -1147,8 +1148,8 @@ ZL1:;
 		lx->clear      = CAT(LX_PREFIX, _dynclear);
 		lx->free       = CAT(LX_PREFIX, _dynfree);
 
-	/* XXX */
-	lx->free = NULL;
+		/* XXX */
+		lx->free = NULL;
 
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
@@ -1166,9 +1167,6 @@ ZL1:;
 			const struct ast_alt *q;
 			struct ast_term *t;
 			struct ast_rule *r;
-			int ok;
-
-			ok = 1;
 
 			for (p = g; p != NULL; p = p->next) {
 				for (q = p->alts; q != NULL; q = q->next) {
@@ -1186,11 +1184,8 @@ ZL1:;
 						}
 
 						if (!allow_undefined) {
-							fprintf(stderr, "production rule <%s> not defined\n", t->u.rule->name);
-							/* TODO: print location of this and previous definition */
+							err(lex_state, "production rule <%s> not defined", t->u.rule->name);
 							/* XXX: would leak the ast_rule here */
-
-							ok = 0;
 							continue;
 						}
 
@@ -1207,15 +1202,12 @@ ZL1:;
 					}
 				}
 			}
-
-			if (!ok) {
-				exit(EXIT_FAILURE);
-			}
 		}
 
+		*errors = lex_state->errors;
 		return g;
 	}
 
-#line 1220 "src/wsn/parser.c"
+#line 1212 "src/wsn/parser.c"
 
 /* END OF FILE */

--- a/src/wsn/parser.h
+++ b/src/wsn/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 316 "src/parser.act"
+#line 311 "src/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -24,7 +24,7 @@
 extern void prod_wsn(lex_state, act_state, map_rule *);
 /* BEGINNING OF TRAILER */
 
-#line 871 "src/parser.act"
+#line 861 "src/parser.act"
 
 
 #line 31 "src/wsn/parser.h"


### PR DESCRIPTION
Using exit(EXIT_FAILURE) in the middle of a function makes kgt hard to
be embedded as a library, because it interrupts the caller.

The previous patch removed usage of exit for every generators:
https://github.com/katef/kgt/pull/40

This one removes usage of exit for every parser. The parsing_error
struct is introduced to list all the errors.

Issue:
- https://github.com/katef/kgt/issues/38
- https://github.com/ArthurSonzogni/Diagon/issues/19