### PR TITLE
Add support for JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ SUBDIR += src/rrtext
 SUBDIR += src/rrdot
 SUBDIR += src/svg
 SUBDIR += src/html5
+SUBDIR += src/json
 SUBDIR += src
 
 .include <subdir.mk>

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ ${BUILD}/bin/kgt: ${BUILD}/src/xalloc.o
 	${PART:Mebnfhtml5} \
 	${PART:Mrrd} ${PART:Mrrdot} ${PART:Mrrdump} ${PART:Mrrtdump} \
 	${PART:Mrrparcon} ${PART:Mrrll} ${PART:Mrrta} ${PART:Mrrtext} \
-	${PART:Msvg} ${PART:Mhtml5}
+	${PART:Msvg} ${PART:Mhtml5} ${PART:Mjson}
 ${BUILD}/bin/kgt: ${BUILD}/lib/${part}.o
 .endfor
 

--- a/src/json/Makefile
+++ b/src/json/Makefile
@@ -1,0 +1,10 @@
+.include "../../share/mk/top.mk"
+
+SRC += src/json/output.c
+
+PART += json
+
+.for src in ${SRC:Msrc/json/*.c}
+${BUILD}/lib/json.o:    ${BUILD}/${src:R}.o
+${BUILD}/lib/json.opic: ${BUILD}/${src:R}.opic
+.endfor

--- a/src/json/io.h
+++ b/src/json/io.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 John Scott
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef KGT_JSON_IO_H
+#define KGT_JSON_IO_H
+
+#include "../compiler_specific.h"
+
+struct ast_rule;
+
+#define json_ast_unsupported (FEATURE_AST_INVISIBLE)
+
+WARN_UNUSED_RESULT
+int
+json_output(const struct ast_rule *grammar);
+
+#endif

--- a/src/json/output.c
+++ b/src/json/output.c
@@ -14,11 +14,263 @@
 
 #include "io.h"
 
+static void output_string(const char *string) {
+    fputs("\"", stdout);
+
+    for(; *string ; string++) {
+        if (*string == '\"') {
+            fputs("\\\"", stdout);
+        } else {
+            putc(*string, stdout);
+        }
+    }
+
+    fputs("\"", stdout);
+}
+
+void output_txt(const struct txt t) {
+	size_t i;
+	fputs("\"", stdout);
+	for (i = 0; i < t.n; i++) {
+		if (t.p[i] == '\"') {
+			fputs("\\\"", stdout);
+		} else {
+			putc(t.p[i], stdout);
+		}
+	}
+	fputs("\"", stdout);
+}
+
+
+WARN_UNUSED_RESULT
+static int
+output_alts(const struct ast_alt *alts);
+
+
+WARN_UNUSED_RESULT
+static int
+output_term_rule(const struct ast_rule *rule) {
+	fputs(",", stdout);
+	output_string("rule");
+	fputs(":", stdout);
+	output_string(rule->name);
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_term_token(const char *token) {
+	fputs(",", stdout);
+	output_string("token");
+	fputs(":", stdout);
+	output_string(token);
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_term_prose(const char *prose) {
+	fputs(",", stdout);
+	output_string("prose");
+	fputs(":", stdout);
+	output_string(prose);
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_term_group(const struct ast_alt *group) {
+	fputs(",", stdout);
+	output_string("group");
+	fputs(":", stdout);
+	if (!output_alts(group))
+		return 0;
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_term_literal(const struct txt literal) {
+	size_t i;
+	fputs(",", stdout);
+	output_string("literal");
+	fputs(":", stdout);
+	output_txt(literal);
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_term(const struct ast_term *term)
+{
+	fputs("{", stdout);
+	output_string("$isa");
+	fputs(":", stdout);
+	switch (term->type) {
+		case TYPE_EMPTY: output_string("empty"); break;
+		case TYPE_RULE: output_string("rule"); break;
+		case TYPE_CS_LITERAL: output_string("cs_literal"); break;
+		case TYPE_CI_LITERAL: output_string("ci_literal"); break;
+		case TYPE_TOKEN: output_string("token"); break;
+		case TYPE_PROSE: output_string("prose"); break;
+		case TYPE_GROUP: output_string("group"); break;
+		default: fputs("null", stdout); break;
+	}
+
+	if (term->min != 1) {
+		fputs(",", stdout);
+		output_string("min");
+		fputs(":", stdout);
+		printf("%d", term->min);
+	}
+
+	if (term->max != 1) {
+		fputs(",", stdout);
+		output_string("max");
+		fputs(":", stdout);
+		printf("%d", term->max);
+	}
+
+	if (term->invisible != 0) {
+		fputs(",", stdout);
+		output_string("invisible");
+		fputs(":true", stdout);
+	}
+
+	switch (term->type) {
+		case TYPE_EMPTY:
+			break;
+		case TYPE_RULE:
+			if (!output_term_rule(term->u.rule))
+				return 0;
+			break;
+		case TYPE_CS_LITERAL:
+		case TYPE_CI_LITERAL:
+			if (!output_term_literal(term->u.literal))
+				return 0;
+			break;
+		case TYPE_TOKEN:
+			if (!output_term_token(term->u.token))
+				return 0;
+		 	break;
+		case TYPE_PROSE:
+			if (!output_term_prose(term->u.prose))
+				return 0;
+			break;
+		case TYPE_GROUP:
+			if (!output_term_group(term->u.group))
+				return 0;
+			break;
+	}
+
+	fputs("}", stdout);
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_alt(const struct ast_alt *alt)
+{
+	const struct ast_term *term;
+
+	fputs("{", stdout);
+	output_string("$isa");
+	fputs(":", stdout);
+	output_string("alt");
+
+	if (alt->invisible != 0) {
+		fputs(",", stdout);
+		output_string("invisible");
+		fputs(":true", stdout);
+	}
+
+	if (alt->terms) {
+		fputs(",", stdout);
+		output_string("terms");
+		fputs(":", stdout);
+		fputs("[", stdout);
+
+		for (term = alt->terms; term != NULL; term = term->next) {
+			if (term != alt->terms)
+					fputs(",", stdout);
+
+			if (!output_term(term))
+				return 0;
+		}
+
+		fputs("]", stdout);
+	}
+	fputs("}", stdout);
+
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_alts(const struct ast_alt *alts)
+{
+	const struct ast_alt *alt;
+
+	fputs("[", stdout);
+
+	for (alt = alts; alt != NULL; alt = alt->next) {
+		if (alt != alts)
+				fputs(",", stdout);
+
+		if (!output_alt(alt))
+			return 0;
+	}
+
+	fputs("]", stdout);
+	return 1;
+}
+
+WARN_UNUSED_RESULT
+static int
+output_rule(const struct ast_rule *rule)
+{
+	fputs("{", stdout);
+	output_string("$isa");
+	fputs(":", stdout);
+	output_string("rule");
+
+	if (rule->name) {
+		fputs(",", stdout);
+		output_string("name");
+		fputs(":", stdout);
+		output_string(rule->name);
+	}
+
+	if (rule->alts) {
+		fputs(",", stdout);
+		output_string("alts");
+		fputs(":", stdout);
+		if (!output_alts(rule->alts))
+			return 0;
+	}
+
+	fputs("}", stdout);
+
+	return 1;
+}
+
 WARN_UNUSED_RESULT
 int
 json_output(const struct ast_rule *grammar)
 {
-	fprintf(stderr, "unimplemented\n");
+	const struct ast_rule *rule;
 
-	return 0;
+	fputs("[", stdout);
+
+	for (rule = grammar; rule != NULL; rule = rule->next) {
+		if (rule != grammar)
+				fputs(",", stdout);
+
+		if (!output_rule(rule))
+			return 0;
+	}
+
+	fputs("]\n", stdout);
+
+	return 1;
 }

--- a/src/json/output.c
+++ b/src/json/output.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 John Scott
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "../txt.h"
+#include "../ast.h"
+
+#include "io.h"
+
+WARN_UNUSED_RESULT
+int
+json_output(const struct ast_rule *grammar)
+{
+	fprintf(stderr, "unimplemented\n");
+
+	return 0;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,7 @@
 #include "rrtext/io.h"
 #include "svg/io.h"
 #include "html5/io.h"
+#include "json/io.h"
 
 int debug = 0;
 int prettify = 1;
@@ -81,7 +82,8 @@ struct io {
 	{ "rrutf8",   NULL,           rrutf8_output,   0, 0 },
 	{ "svg",      NULL,           svg_output,      0, 0 },
 	{ "html5",    NULL,           html5_output,    0, 0 },
-	{ "xhtml5",   NULL,           xhtml5_output,   0, 0 }
+	{ "xhtml5",   NULL,           xhtml5_output,   0, 0 },
+    { "json",       NULL,           json_output,        json_ast_unsupported, 0 }
 };
 
 enum io_dir {


### PR DESCRIPTION
Being able convert various kinds of BNF to JSON allows other tools to be used. Here's a basic example of something I'm doing:

```shell
kgt -l wsn -e json < examples/c_syntax.wsn | json_pp -json_opt pretty,canonical
``` 

This functionality would really help me in two small projects I've been work on: https://github.com/jjrscott/banteng and https://github.com/jjrscott/Prism.app.