### PR TITLE
Fix building with newer bmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .MAKEFLAGS: -r -m share/mk
 
+.MAIN: all
+
+.SYSPATH:
+.SYSPATH: $(.CURDIR)/share/mk
+
 # targets
 all::  mkdir .WAIT dep .WAIT prog
 dep::


### PR DESCRIPTION
The same fix as for libfsm: https://github.com/katef/libfsm/pull/406

Fixes #62
