### PR TITLE
Allow running passes multiple times.

### DIFF
--- a/src/rrd/pretty.c
+++ b/src/rrd/pretty.c
@@ -81,7 +81,7 @@ rrd_pretty(struct node **rrd)
 		do {
 			changed = 0;
 			node_walk(f[i], &changed, rrd);
-		} while (changed && !limit--);
+		} while (changed && limit--);
 	}
 }
 


### PR DESCRIPTION
Previously, `limit` was always nonzero, which meant that `!limit--` was always false, so the inner loop would never iterate.

Closes #61
Closes #66

```
alona@Ashtabula:~/dev$ cat issue61.ebnf 
binding-names = {name, ","}, name, ",", name;
alona@Ashtabula:~/dev$ cat issue66.ebnf 
binding-names = {name, ","}, name, ",", name, [","];
alona@Ashtabula:~/dev$ ./kgt/build/bin/kgt -l iso-ebnf -e rrutf8 < ./issue61.ebnf 
Segmentation fault
alona@Ashtabula:~/dev$ ./kgt/build/bin/kgt -l iso-ebnf -e rrutf8 < ./issue66.ebnf 
binding-names:
                      ╭────>────╮
                      │         │
    │├──╭── name ──╮──╯── "," ──╰──┤│
        │          │
        ╰── "," ───╯

alona@Ashtabula:~/dev$ ./kgt-2/build/bin/kgt -l iso-ebnf -e rrutf8 < ./issue61.ebnf 
binding-names:
    │├──╭── name ── "," ──╮── name ──┤│
        │                 │
        ╰────────<────────╯

alona@Ashtabula:~/dev$ ./kgt-2/build/bin/kgt -l iso-ebnf -e rrutf8 < ./issue66.ebnf 
binding-names:
                                     ╭────>────╮
                                     │         │
    │├──╭── name ── "," ──╮── name ──╯── "," ──╰──┤│
        │                 │
        ╰────────<────────╯
```

I'm not sure how to test this.